### PR TITLE
Add tasks tables and types

### DIFF
--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -104,9 +104,120 @@ export interface Database {
           updated_at?: string
         }
       }
+      tasks: {
+        Row: {
+          id: string
+          household_id: string
+          title: string
+          description: string | null
+          phase: TaskPhase
+          assigned_to: string | null
+          due_date: string | null
+          completed: boolean
+          completed_at: string | null
+          completed_by: string | null
+          priority: TaskPriority
+          category: string | null
+          template_id: string | null
+          dependencies: string[] | null
+          estimated_duration: number | null
+          actual_duration: number | null
+          notes: string | null
+          attachments: any | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          household_id: string
+          title: string
+          description?: string | null
+          phase: TaskPhase
+          assigned_to?: string | null
+          due_date?: string | null
+          completed?: boolean
+          completed_at?: string | null
+          completed_by?: string | null
+          priority?: TaskPriority
+          category?: string | null
+          template_id?: string | null
+          dependencies?: string[] | null
+          estimated_duration?: number | null
+          actual_duration?: number | null
+          notes?: string | null
+          attachments?: any | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          household_id?: string
+          title?: string
+          description?: string | null
+          phase?: TaskPhase
+          assigned_to?: string | null
+          due_date?: string | null
+          completed?: boolean
+          completed_at?: string | null
+          completed_by?: string | null
+          priority?: TaskPriority
+          category?: string | null
+          template_id?: string | null
+          dependencies?: string[] | null
+          estimated_duration?: number | null
+          actual_duration?: number | null
+          notes?: string | null
+          attachments?: any | null
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      checklist_templates: {
+        Row: {
+          id: string
+          title: string
+          description: string | null
+          phase: TaskPhase
+          assigned_role: HouseholdRole | null
+          days_before_move: number | null
+          priority: TaskPriority
+          category: string | null
+          conditions: any | null
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          title: string
+          description?: string | null
+          phase: TaskPhase
+          assigned_role?: HouseholdRole | null
+          days_before_move?: number | null
+          priority?: TaskPriority
+          category?: string | null
+          conditions?: any | null
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          title?: string
+          description?: string | null
+          phase?: TaskPhase
+          assigned_role?: HouseholdRole | null
+          days_before_move?: number | null
+          priority?: TaskPriority
+          category?: string | null
+          conditions?: any | null
+          created_at?: string
+          updated_at?: string
+        }
+      }
     }
   }
 }
 
 export type HouseholdRole = 'vertragsmanager' | 'packbeauftragte' | 'finanzperson' | 'renovierer' | 'haustierverantwortliche'
 export type PropertyType = 'miete' | 'eigentum'
+export type TaskPhase = 'vor_umzug' | 'umzugstag' | 'nach_umzug' | 'langzeit'
+export type TaskPriority = 'niedrig' | 'mittel' | 'hoch' | 'kritisch'

--- a/supabase/migrations/20250628000000-6d7126d0-0de4-4b48-af7c-2a077ca7b459.sql
+++ b/supabase/migrations/20250628000000-6d7126d0-0de4-4b48-af7c-2a077ca7b459.sql
@@ -1,0 +1,79 @@
+-- Migration to add tasks and checklist_templates tables
+
+-- Enums for tasks
+CREATE TYPE public.task_phase AS ENUM ('vor_umzug', 'umzugstag', 'nach_umzug', 'langzeit');
+CREATE TYPE public.task_priority AS ENUM ('niedrig', 'mittel', 'hoch', 'kritisch');
+
+-- Checklist templates table
+CREATE TABLE public.checklist_templates (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  title TEXT NOT NULL,
+  description TEXT,
+  phase task_phase NOT NULL,
+  assigned_role household_role,
+  days_before_move INTEGER,
+  priority task_priority NOT NULL DEFAULT 'mittel',
+  category TEXT,
+  conditions JSONB,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Tasks table
+CREATE TABLE public.tasks (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  household_id UUID REFERENCES public.households ON DELETE CASCADE NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  phase task_phase NOT NULL,
+  assigned_to UUID REFERENCES public.household_members,
+  due_date DATE,
+  completed BOOLEAN NOT NULL DEFAULT false,
+  completed_at TIMESTAMP WITH TIME ZONE,
+  completed_by UUID REFERENCES auth.users,
+  priority task_priority NOT NULL DEFAULT 'mittel',
+  category TEXT,
+  template_id UUID REFERENCES public.checklist_templates,
+  dependencies UUID[],
+  estimated_duration INTEGER,
+  actual_duration INTEGER,
+  notes TEXT,
+  attachments JSONB,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Enable RLS
+ALTER TABLE public.checklist_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.tasks ENABLE ROW LEVEL SECURITY;
+
+-- Policies for checklist_templates (read-only for all authenticated users)
+CREATE POLICY "All users can view templates"
+  ON public.checklist_templates FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Policies for tasks
+CREATE POLICY "Users can view tasks of their households"
+  ON public.tasks FOR SELECT
+  USING (
+    household_id IN (
+      SELECT household_id FROM public.household_members
+      WHERE user_id = auth.uid() OR (user_id IS NULL AND email = auth.email())
+    )
+  );
+
+CREATE POLICY "Assigned users can update their tasks"
+  ON public.tasks FOR UPDATE
+  USING (assigned_to IN (
+    SELECT id FROM public.household_members WHERE user_id = auth.uid()
+  ));
+
+CREATE POLICY "Household owners can manage all tasks"
+  ON public.tasks FOR ALL
+  USING (
+    household_id IN (
+      SELECT id FROM public.households WHERE created_by = auth.uid()
+    )
+  );
+


### PR DESCRIPTION
## Summary
- add database enums and tables for tasks and checklist templates
- add RLS policies for new tables
- update generated TypeScript types with tasks and checklist templates

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e5a52c35c83208c7df6b9c142e2c1