### PR TITLE
Implement invitation onboarding

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -8,6 +8,8 @@ import { Progress } from '@/components/ui/progress'
 import { Badge } from '@/components/ui/badge'
 import { Users, CheckCircle, Calendar, Plus, Home, LogOut } from 'lucide-react'
 import { OnboardingFlow } from './onboarding/OnboardingFlow'
+import { InviteOnboarding } from './onboarding/InviteOnboarding'
+import { usePendingInvitations } from '@/hooks/usePendingInvitations'
 import { HouseholdOverview } from './household/HouseholdOverview'
 import { MemberManagement } from './household/MemberManagement'
 import { EditHouseholdForm } from './household/EditHouseholdForm'
@@ -29,6 +31,7 @@ export const Dashboard = () => {
   const [activeHousehold, setActiveHousehold] = useState<ExtendedHousehold | null>(null)
   const [dailyTip] = useState(getRandomTip())
   const [showEditDialog, setShowEditDialog] = useState(false)
+  const { invitations, loading: inviteLoading, refetch: refetchInvites } = usePendingInvitations()
 
   // Show auth page if not logged in
   if (!authLoading && !user) {
@@ -36,7 +39,7 @@ export const Dashboard = () => {
   }
 
   // Loading state
-  if (authLoading || loading) {
+  if (authLoading || loading || inviteLoading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
         <div className="text-center">
@@ -118,6 +121,18 @@ export const Dashboard = () => {
   const backToDashboard = () => {
     setViewMode('dashboard')
     setActiveHousehold(null)
+  }
+
+  if (viewMode === 'dashboard' && invitations.length > 0) {
+    return (
+      <InviteOnboarding
+        invitation={invitations[0]}
+        onComplete={() => {
+          refetchInvites()
+          setViewMode('dashboard')
+        }}
+      />
+    )
   }
 
   // Render different views

--- a/src/components/onboarding/InviteOnboarding.tsx
+++ b/src/components/onboarding/InviteOnboarding.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { useAuth } from '@/contexts/AuthContext'
+import { useToast } from '@/hooks/use-toast'
+import { HOUSEHOLD_ROLES } from '@/config/roles'
+import { useHouseholdMembers } from '@/hooks/useHouseholdMembers'
+import { supabase } from '@/integrations/supabase/client'
+import { HouseholdMember } from '@/types/household'
+
+interface Invitation extends HouseholdMember {
+  households: { name: string; move_date: string }
+}
+
+interface InviteOnboardingProps {
+  invitation: Invitation
+  onComplete: () => void
+}
+
+export const InviteOnboarding = ({ invitation, onComplete }: InviteOnboardingProps) => {
+  const { user } = useAuth()
+  const { toast } = useToast()
+  const { acceptInvitation } = useHouseholdMembers(invitation.household_id)
+  const [name, setName] = useState(invitation.name || user?.user_metadata?.full_name || '')
+  const [role, setRole] = useState<string>(invitation.role || '')
+  const [saving, setSaving] = useState(false)
+
+  const handleAccept = async () => {
+    if (!user) return
+    setSaving(true)
+    try {
+      await supabase
+        .from('household_members')
+        .update({ name, role: role || null })
+        .eq('id', invitation.id)
+
+      await acceptInvitation(invitation.id, user.id)
+
+      await supabase.from('profiles').update({ full_name: name }).eq('id', user.id)
+
+      toast({ title: 'Einladung angenommen' })
+      onComplete()
+    } catch (error) {
+      toast({
+        title: 'Fehler',
+        description: error instanceof Error ? error.message : 'Aktion fehlgeschlagen',
+        variant: 'destructive'
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
+      <Card className="max-w-md w-full bg-white shadow-lg">
+        <CardHeader>
+          <CardTitle className="text-lg">Haushaltseinladung</CardTitle>
+          <CardDescription>
+            Du wurdest zu "{invitation.households.name}" eingeladen
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label htmlFor="name">Dein Name</Label>
+            <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+          </div>
+          <div>
+            <Label htmlFor="role">Rolle (optional)</Label>
+            <Select value={role} onValueChange={(v) => setRole(v)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Rolle auswählen" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="">Keine Rolle</SelectItem>
+                {HOUSEHOLD_ROLES.map((r) => (
+                  <SelectItem key={r.key} value={r.key}>
+                    <span className="mr-1">{r.icon}</span>
+                    {r.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button onClick={handleAccept} className="w-full bg-green-600 hover:bg-green-700" disabled={saving}>
+            {saving ? 'Speichere...' : 'Einladung annehmen'}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/hooks/usePendingInvitations.ts
+++ b/src/hooks/usePendingInvitations.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react'
+import { supabase } from '@/integrations/supabase/client'
+import { useAuth } from '@/contexts/AuthContext'
+import { HouseholdMember } from '@/types/household'
+
+interface Invitation extends HouseholdMember {
+  households: {
+    name: string
+    move_date: string
+  }
+}
+
+export function usePendingInvitations() {
+  const { user } = useAuth()
+  const [invitations, setInvitations] = useState<Invitation[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const fetchInvites = async () => {
+    if (!user) return
+    setLoading(true)
+    const { data, error } = await supabase
+      .from('household_members')
+      .select('*, households!inner(name, move_date)')
+      .eq('email', user.email)
+      .is('joined_at', null)
+
+    if (!error) {
+      setInvitations((data as Invitation[]) || [])
+    }
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    fetchInvites()
+  }, [user])
+
+  return { invitations, loading, refetch: fetchInvites }
+}


### PR DESCRIPTION
## Summary
- add hook to fetch pending invitations for current user
- add component for invited member onboarding
- integrate invitation onboarding into dashboard flow

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e71d9f4ec83209c78a75882269b5d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added onboarding flow for accepting household invitations directly from the dashboard.
  * Introduced a dedicated interface for handling pending invitations, allowing users to review and accept invites with personalized details.

* **Improvements**
  * Dashboard now prioritizes pending invitations, guiding users through onboarding before displaying main content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->