### PR TITLE
Implement invitation onboarding

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -8,6 +8,8 @@ import { Progress } from '@/components/ui/progress'
 import { Badge } from '@/components/ui/badge'
 import { Users, CheckCircle, Calendar, Plus, Home, LogOut } from 'lucide-react'
 import { OnboardingFlow } from './onboarding/OnboardingFlow'
+import { InviteOnboarding } from './onboarding/InviteOnboarding'
+import { usePendingInvitations } from '@/hooks/usePendingInvitations'
 import { HouseholdOverview } from './household/HouseholdOverview'
 import { MemberManagement } from './household/MemberManagement'
 import { EditHouseholdForm } from './household/EditHouseholdForm'
@@ -29,6 +31,17 @@ export const Dashboard = () => {
   const [activeHousehold, setActiveHousehold] = useState<ExtendedHousehold | null>(null)
   const [dailyTip] = useState(getRandomTip())
   const [showEditDialog, setShowEditDialog] = useState(false)
+  const { invitations, loading: inviteLoading, error: inviteError, refetch: refetchInvites } = usePendingInvitations()
+
+  useEffect(() => {
+    if (inviteError) {
+      toast({
+        title: 'Fehler beim Laden der Einladungen',
+        description: inviteError.message,
+        variant: 'destructive'
+      })
+    }
+  }, [inviteError, toast])
 
   // Show auth page if not logged in
   if (!authLoading && !user) {
@@ -36,7 +49,7 @@ export const Dashboard = () => {
   }
 
   // Loading state
-  if (authLoading || loading) {
+  if (authLoading || loading || inviteLoading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
         <div className="text-center">
@@ -118,6 +131,18 @@ export const Dashboard = () => {
   const backToDashboard = () => {
     setViewMode('dashboard')
     setActiveHousehold(null)
+  }
+
+  if (viewMode === 'dashboard' && invitations.length > 0) {
+    return (
+      <InviteOnboarding
+        invitation={invitations[0]}
+        onComplete={() => {
+          refetchInvites()
+          setViewMode('dashboard')
+        }}
+      />
+    )
   }
 
   // Render different views

--- a/src/components/onboarding/InviteOnboarding.tsx
+++ b/src/components/onboarding/InviteOnboarding.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { useAuth } from '@/contexts/AuthContext'
+import { useToast } from '@/hooks/use-toast'
+import { HOUSEHOLD_ROLES } from '@/config/roles'
+import { supabase } from '@/integrations/supabase/client'
+import { Invitation } from '@/types/invitation'
+
+interface InviteOnboardingProps {
+  invitation: Invitation
+  onComplete: () => void
+}
+
+export const InviteOnboarding = ({ invitation, onComplete }: InviteOnboardingProps) => {
+  const { user } = useAuth()
+  const { toast } = useToast()
+  const [name, setName] = useState(invitation.name || user?.user_metadata?.full_name || '')
+  const [role, setRole] = useState<string>(invitation.role || '')
+  const [saving, setSaving] = useState(false)
+  const [nameError, setNameError] = useState<string | null>(null)
+
+  const handleAccept = async () => {
+    if (!user) return
+    if (!name.trim()) {
+      setNameError('Bitte gib deinen Namen an.')
+      return
+    }
+    setSaving(true)
+    try {
+      const { error } = await supabase.rpc('accept_household_invitation', {
+        p_member_id: invitation.id,
+        p_user_id: user.id,
+        p_name: name.trim(),
+        p_role: role || null
+      })
+
+      if (error) throw error
+
+      toast({ title: 'Einladung angenommen' })
+      onComplete()
+    } catch (error) {
+      toast({
+        title: 'Fehler',
+        description: error instanceof Error ? error.message : 'Aktion fehlgeschlagen',
+        variant: 'destructive'
+      })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
+      <Card className="max-w-md w-full bg-white shadow-lg">
+        <CardHeader>
+          <CardTitle className="text-lg">Haushaltseinladung</CardTitle>
+          <CardDescription>
+            Du wurdest zu "{invitation.households.name}" eingeladen
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label htmlFor="name">Dein Name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value)
+                if (e.target.value.trim()) setNameError(null)
+              }}
+              className={nameError ? 'border-red-500' : ''}
+            />
+            {nameError && (
+              <p className="text-sm text-red-600 mt-1">{nameError}</p>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="role">Rolle (optional)</Label>
+            <Select value={role} onValueChange={(v) => setRole(v)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Rolle auswählen" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="">Keine Rolle</SelectItem>
+                {HOUSEHOLD_ROLES.map((r) => (
+                  <SelectItem key={r.key} value={r.key}>
+                    <span className="mr-1">{r.icon}</span>
+                    {r.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button
+            onClick={handleAccept}
+            className="w-full bg-green-600 hover:bg-green-700"
+            disabled={saving || !name.trim()}
+          >
+            {saving ? (
+              <span className="flex items-center justify-center gap-2">
+                <span className="h-4 w-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                Wird gespeichert...
+              </span>
+            ) : (
+              'Einladung annehmen'
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/hooks/usePendingInvitations.ts
+++ b/src/hooks/usePendingInvitations.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect, useCallback } from 'react'
+import { supabase } from '@/integrations/supabase/client'
+import { useAuth } from '@/contexts/AuthContext'
+import { Invitation } from '@/types/invitation'
+
+export function usePendingInvitations() {
+  const { user } = useAuth()
+  const [invitations, setInvitations] = useState<Invitation[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+
+  const fetchInvites = useCallback(async () => {
+    if (!user) return
+    setLoading(true)
+    try {
+      const { data, error: queryError } = await supabase
+        .from('household_members')
+        .select('*, households!inner(name, move_date)')
+        .eq('email', user.email)
+        .is('joined_at', null)
+
+      if (queryError) throw queryError
+
+      setInvitations((data as Invitation[]) || [])
+      setError(null)
+    } catch (err) {
+      console.error('Error fetching invitations:', err)
+      setError(err instanceof Error ? err : new Error('Unknown error'))
+    } finally {
+      setLoading(false)
+    }
+  }, [user])
+
+  useEffect(() => {
+    fetchInvites()
+  }, [user, fetchInvites])
+
+  return { invitations, loading, error, refetch: fetchInvites }
+}

--- a/src/types/invitation.ts
+++ b/src/types/invitation.ts
@@ -1,0 +1,8 @@
+import { HouseholdMember } from './household'
+
+export interface Invitation extends HouseholdMember {
+  households: {
+    name: string
+    move_date: string
+  }
+}

--- a/supabase/migrations/20250628010000-accept-invitation-function.sql
+++ b/supabase/migrations/20250628010000-accept-invitation-function.sql
@@ -1,0 +1,24 @@
+-- Function to accept an invitation atomically
+CREATE OR REPLACE FUNCTION public.accept_household_invitation(
+  p_member_id UUID,
+  p_user_id UUID,
+  p_name TEXT,
+  p_role household_role
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = 'public'
+AS $$
+BEGIN
+  UPDATE public.household_members
+    SET name = p_name,
+        role = p_role,
+        user_id = p_user_id,
+        joined_at = now()
+    WHERE id = p_member_id;
+
+  UPDATE public.profiles
+    SET full_name = p_name
+    WHERE id = p_user_id;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add hook to fetch pending invitations for current user
- add component for invited member onboarding
- integrate invitation onboarding into dashboard flow
- improve error handling and validation
- add SQL function for atomic invitation acceptance

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e71d9f4ec83209c78a75882269b5d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added onboarding flow for accepting household invitations, including a dedicated interface for reviewing and accepting invitations.
  * Dashboard now prioritizes invitation onboarding when pending invitations exist.
  * Users can update their name and select a role when accepting an invitation.
  * Invitations are refreshed automatically after onboarding is completed.

* **Bug Fixes**
  * Improved error handling and user notifications during invitation loading and onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->