### PR TITLE
Add household merging function

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -69,7 +69,12 @@ export const Dashboard = () => {
         children_count: data.childrenCount,
         pets_count: data.petsCount,
         property_type: data.propertyType,
-        postal_code: data.postalCode
+        postal_code: data.postalCode,
+        old_address: data.oldAddress,
+        new_address: data.newAddress,
+        living_space: data.livingSpace,
+        rooms: data.rooms,
+        furniture_volume: data.furnitureVolume
       })
 
       // Add members if any

--- a/src/components/household/EditHouseholdForm.tsx
+++ b/src/components/household/EditHouseholdForm.tsx
@@ -16,6 +16,11 @@ interface EditHouseholdFormProps {
     pets_count: number
     property_type: 'miete' | 'eigentum'
     postal_code: string | null
+    old_address: string | null
+    new_address: string | null
+    living_space: number | null
+    rooms: number | null
+    furniture_volume: number | null
   }) => void
   onCancel: () => void
 }
@@ -28,21 +33,35 @@ export const EditHouseholdForm = ({ household, onSubmit, onCancel }: EditHouseho
     children_count: household.children_count,
     pets_count: household.pets_count,
     property_type: household.property_type,
-    postal_code: household.postal_code || ''
+    postal_code: household.postal_code || '',
+    old_address: household.old_address || '',
+    new_address: household.new_address || '',
+    living_space: household.living_space || 0,
+    rooms: household.rooms || 0,
+    furniture_volume: household.furniture_volume || 0
   })
 
   const updateField = (field: string, value: string) => {
     setForm(prev => ({ ...prev, [field]: value }))
   }
 
+  const parseNumber = (value: string): number | null => {
+    return value === '' || value === null ? null : Number(value)
+  }
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     onSubmit({
       ...form,
-      household_size: Number(form.household_size),
-      children_count: Number(form.children_count),
-      pets_count: Number(form.pets_count),
-      postal_code: form.postal_code || null
+      household_size: parseNumber(form.household_size) ?? 0,
+      children_count: parseNumber(form.children_count) ?? 0,
+      pets_count: parseNumber(form.pets_count) ?? 0,
+      postal_code: form.postal_code || null,
+      living_space: parseNumber(form.living_space),
+      rooms: parseNumber(form.rooms),
+      furniture_volume: parseNumber(form.furniture_volume),
+      old_address: form.old_address || null,
+      new_address: form.new_address || null
     })
   }
 
@@ -131,6 +150,57 @@ export const EditHouseholdForm = ({ household, onSubmit, onCancel }: EditHouseho
           onChange={(e) => updateField('postal_code', e.target.value)}
           maxLength={5}
         />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="edit-old">Aktuelle Adresse (optional)</Label>
+        <Input
+          id="edit-old"
+          value={form.old_address}
+          onChange={(e) => updateField('old_address', e.target.value)}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="edit-new">Neue Adresse</Label>
+        <Input
+          id="edit-new"
+          value={form.new_address}
+          onChange={(e) => updateField('new_address', e.target.value)}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="edit-living">Wohnfläche (m²)</Label>
+          <Input
+            id="edit-living"
+            type="number"
+            min={0}
+            value={form.living_space}
+            onChange={(e) => updateField('living_space', e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="edit-rooms">Zimmer</Label>
+          <Input
+            id="edit-rooms"
+            type="number"
+            min={0}
+            value={form.rooms}
+            onChange={(e) => updateField('rooms', e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="edit-volume">Möbelvolumen (m³)</Label>
+          <Input
+            id="edit-volume"
+            type="number"
+            min={0}
+            value={form.furniture_volume}
+            onChange={(e) => updateField('furniture_volume', e.target.value)}
+          />
+        </div>
       </div>
 
       <div className="flex justify-end gap-2 pt-4">

--- a/src/components/household/HouseholdOverview.tsx
+++ b/src/components/household/HouseholdOverview.tsx
@@ -92,6 +92,26 @@ export const HouseholdOverview = ({
                 </div>
               </div>
             )}
+
+            {household.new_address && (
+              <div className="flex items-center space-x-2">
+                <MapPin className="h-5 w-5 text-blue-600" />
+                <div>
+                  <p className="text-sm text-gray-600">Neue Adresse</p>
+                  <p className="font-semibold">{household.new_address}</p>
+                </div>
+              </div>
+            )}
+
+            {household.living_space && (
+              <div className="flex items-center space-x-2">
+                <span className="text-xl">📐</span>
+                <div>
+                  <p className="text-sm text-gray-600">Wohnfläche</p>
+                  <p className="font-semibold">{household.living_space} m²</p>
+                </div>
+              </div>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -18,6 +18,11 @@ interface OnboardingData {
   petsCount: number
   propertyType: PropertyType | ''
   postalCode: string
+  oldAddress: string
+  newAddress: string
+  livingSpace: number
+  rooms: number
+  furnitureVolume: number
   members: Array<{
     name: string
     email: string
@@ -40,6 +45,11 @@ export const OnboardingFlow = ({ onComplete, onSkip }: OnboardingFlowProps) => {
     petsCount: 0,
     propertyType: '',
     postalCode: '',
+    oldAddress: '',
+    newAddress: '',
+    livingSpace: 0,
+    rooms: 0,
+    furnitureVolume: 0,
     members: []
   })
 
@@ -92,7 +102,13 @@ export const OnboardingFlow = ({ onComplete, onSkip }: OnboardingFlowProps) => {
       case 2:
         return data.householdSize > 0
       case 3:
-        return data.propertyType && data.postalCode.trim()
+        return (
+          data.propertyType &&
+          data.postalCode.trim() &&
+          data.newAddress.trim() &&
+          data.livingSpace > 0 &&
+          data.rooms > 0
+        )
       case 4:
         return true // Members are optional
       case 5:
@@ -259,7 +275,7 @@ export const OnboardingFlow = ({ onComplete, onSkip }: OnboardingFlowProps) => {
                     </SelectContent>
                   </Select>
                 </div>
-                
+
                 <div>
                   <Label htmlFor="postalCode">Postleitzahl deiner neuen Adresse</Label>
                   <Input
@@ -272,6 +288,59 @@ export const OnboardingFlow = ({ onComplete, onSkip }: OnboardingFlowProps) => {
                   <p className="text-sm text-gray-600 mt-1">
                     Hilft uns dabei, regionale Fristen und Ämter zu finden
                   </p>
+                </div>
+
+                <div>
+                  <Label htmlFor="oldAddress">Aktuelle Adresse (optional)</Label>
+                  <Input
+                    id="oldAddress"
+                    value={data.oldAddress}
+                    onChange={(e) => updateData({ oldAddress: e.target.value })}
+                    placeholder="Straße, Hausnummer, Ort"
+                  />
+                </div>
+
+                <div>
+                  <Label htmlFor="newAddress">Neue Adresse</Label>
+                  <Input
+                    id="newAddress"
+                    value={data.newAddress}
+                    onChange={(e) => updateData({ newAddress: e.target.value })}
+                    placeholder="Straße, Hausnummer, Ort"
+                  />
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                  <div>
+                    <Label htmlFor="livingSpace">Wohnfläche (m²)</Label>
+                    <Input
+                      id="livingSpace"
+                      type="number"
+                      min={0}
+                      value={data.livingSpace}
+                      onChange={(e) => updateData({ livingSpace: Number(e.target.value) })}
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="rooms">Zimmer</Label>
+                    <Input
+                      id="rooms"
+                      type="number"
+                      min={0}
+                      value={data.rooms}
+                      onChange={(e) => updateData({ rooms: Number(e.target.value) })}
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="furnitureVolume">Möbelvolumen (m³)</Label>
+                    <Input
+                      id="furnitureVolume"
+                      type="number"
+                      min={0}
+                      value={data.furnitureVolume}
+                      onChange={(e) => updateData({ furnitureVolume: Number(e.target.value) })}
+                    />
+                  </div>
                 </div>
               </div>
             )}
@@ -338,7 +407,7 @@ export const OnboardingFlow = ({ onComplete, onSkip }: OnboardingFlowProps) => {
             {currentStep === 5 && (
               <div className="space-y-4">
                 <h3 className="text-lg font-semibold">Alles bereit für deinen Umzug!</h3>
-                
+
                 <div className="bg-gray-50 p-4 rounded-lg space-y-3">
                   <div><strong>Haushalt:</strong> {data.householdName}</div>
                   <div><strong>Umzugsdatum:</strong> {new Date(data.moveDate).toLocaleDateString('de-DE')}</div>
@@ -347,7 +416,12 @@ export const OnboardingFlow = ({ onComplete, onSkip }: OnboardingFlowProps) => {
                   {data.petsCount > 0 && <div><strong>Haustiere:</strong> {data.petsCount}</div>}
                   <div><strong>Wohnsituation:</strong> {data.propertyType === 'miete' ? 'Mietwohnung' : 'Eigentum'}</div>
                   <div><strong>PLZ:</strong> {data.postalCode}</div>
-                  
+                  {data.oldAddress && <div><strong>Aktuelle Adresse:</strong> {data.oldAddress}</div>}
+                  <div><strong>Neue Adresse:</strong> {data.newAddress}</div>
+                  <div><strong>Wohnfläche:</strong> {data.livingSpace} m²</div>
+                  <div><strong>Zimmer:</strong> {data.rooms}</div>
+                  <div><strong>Möbelvolumen:</strong> {data.furnitureVolume} m³</div>
+
                   {data.members.length > 0 && (
                     <div>
                       <strong>Mitglieder:</strong>
@@ -370,6 +444,10 @@ export const OnboardingFlow = ({ onComplete, onSkip }: OnboardingFlowProps) => {
                     <li>• Alle Mitglieder können Aufgaben übernehmen</li>
                     <li>• Du bekommst rechtliche Hinweise für deinen Umzug</li>
                   </ul>
+                </div>
+
+                <div className="text-xs text-gray-600">
+                  Deine Daten werden ausschließlich für die Organisation des Umzugs genutzt und niemals für Werbezwecke verwendet. Wir bemühen uns, sie sicher zu speichern.
                 </div>
               </div>
             )}

--- a/src/hooks/useHouseholds.ts
+++ b/src/hooks/useHouseholds.ts
@@ -132,6 +132,49 @@ export function useHouseholds() {
     }
   }
 
+  const mergeHouseholds = async (
+    sourceIds: string[],
+    newHouseholdData: Omit<HouseholdInsert, 'created_by'>
+  ) => {
+    if (!user) throw new Error('Benutzer ist nicht angemeldet')
+    if (sourceIds.length < 2) throw new Error('Mindestens zwei Haushalte erforderlich')
+
+    try {
+      const allMembers: Array<{ name: string; email: string; role?: string }> = []
+
+      for (const id of sourceIds) {
+        const { data: members, error } = await supabase
+          .from('household_members')
+          .select('name, email, role')
+          .eq('household_id', id)
+
+        if (error) throw error
+
+        members?.forEach(m => {
+          if (!allMembers.find(am => am.email === m.email && am.name === m.name)) {
+            allMembers.push({
+              name: m.name,
+              email: m.email || '',
+              role: m.role || undefined
+            })
+          }
+        })
+      }
+
+      const newHousehold = await createHousehold(newHouseholdData)
+
+      const membersToAdd = allMembers.filter(m => m.email && m.email !== user.email)
+      if (membersToAdd.length > 0) {
+        await addMembers(newHousehold.id, membersToAdd)
+      }
+
+      await fetchHouseholds()
+      return newHousehold
+    } catch (err) {
+      throw err instanceof Error ? err : new Error('Fehler beim Zusammenführen der Haushalte')
+    }
+  }
+
   useEffect(() => {
     fetchHouseholds()
   }, [user])
@@ -143,6 +186,7 @@ export function useHouseholds() {
     createHousehold,
     addMembers,
     updateHousehold,
+    mergeHouseholds,
     refetch: fetchHouseholds
   }
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -12,6 +12,11 @@ export interface Database {
           pets_count: number
           property_type: 'miete' | 'eigentum'
           postal_code: string | null
+          old_address: string | null
+          new_address: string | null
+          living_space: number | null
+          rooms: number | null
+          furniture_volume: number | null
           invitation_code: string
           created_by: string
           created_at: string
@@ -26,6 +31,11 @@ export interface Database {
           pets_count?: number
           property_type: 'miete' | 'eigentum'
           postal_code?: string | null
+          old_address?: string | null
+          new_address?: string | null
+          living_space?: number | null
+          rooms?: number | null
+          furniture_volume?: number | null
           invitation_code?: string
           created_by: string
           created_at?: string
@@ -40,6 +50,11 @@ export interface Database {
           pets_count?: number
           property_type?: 'miete' | 'eigentum'
           postal_code?: string | null
+          old_address?: string | null
+          new_address?: string | null
+          living_space?: number | null
+          rooms?: number | null
+          furniture_volume?: number | null
           invitation_code?: string
           created_by?: string
           created_at?: string

--- a/supabase/migrations/20250628020000-add-move-details.sql
+++ b/supabase/migrations/20250628020000-add-move-details.sql
@@ -1,0 +1,8 @@
+-- Migration to add additional move details to households
+ALTER TABLE public.households
+  ADD COLUMN IF NOT EXISTS old_address TEXT,
+  ADD COLUMN IF NOT EXISTS new_address TEXT,
+  ADD COLUMN IF NOT EXISTS living_space INTEGER,
+  ADD COLUMN IF NOT EXISTS rooms INTEGER,
+  ADD COLUMN IF NOT EXISTS furniture_volume INTEGER;
+


### PR DESCRIPTION
## Summary
- handle blank numeric fields in EditHouseholdForm
- implement `mergeHouseholds` helper in the household hook

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e9cb4e54c83209fbd8055bb444ef4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new fields for households: old address, new address, living space, number of rooms, and furniture volume. These can now be entered during onboarding and editing, and are displayed in household overviews.
  * Enhanced onboarding process with additional move-related questions and a privacy notice.
  * Introduced the ability to merge multiple households, combining their members into a new household.

* **Bug Fixes**
  * Improved handling and validation of numeric and address inputs in forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->