### PR TITLE
Add address autocomplete and distance features

### DIFF
--- a/src/components/AddressAutocomplete.tsx
+++ b/src/components/AddressAutocomplete.tsx
@@ -1,0 +1,100 @@
+import { useState, useEffect } from 'react'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+interface Suggestion {
+  display_name: string
+  lat: string
+  lon: string
+}
+
+interface AddressAutocompleteProps {
+  value: string
+  onChange: (value: string) => void
+  onSelect?: (s: { lat: number; lon: number }) => void
+  placeholder?: string
+  className?: string
+}
+
+export const AddressAutocomplete = ({
+  value,
+  onChange,
+  onSelect,
+  placeholder,
+  className
+}: AddressAutocompleteProps) => {
+  const [query, setQuery] = useState(value)
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([])
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    setQuery(value)
+  }, [value])
+
+  useEffect(() => {
+    if (query.length < 3) {
+      setSuggestions([])
+      return
+    }
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => {
+      fetch(
+        `https://nominatim.openstreetmap.org/search?format=jsonv2&q=${encodeURIComponent(
+          query
+        )}`,
+        {
+          signal: controller.signal,
+          headers: {
+            'Accept-Language': 'de'
+          }
+        }
+      )
+        .then(res => res.json())
+        .then((data: Suggestion[]) => {
+          setSuggestions(data.slice(0, 5))
+        })
+        .catch(() => {})
+    }, 300)
+
+    return () => {
+      clearTimeout(timeout)
+      controller.abort()
+    }
+  }, [query])
+
+  const handleSelect = (s: Suggestion) => {
+    onChange(s.display_name)
+    onSelect?.({ lat: parseFloat(s.lat), lon: parseFloat(s.lon) })
+    setShow(false)
+  }
+
+  return (
+    <div className={cn('relative', className)}>
+      <Input
+        value={value}
+        onChange={e => {
+          onChange(e.target.value)
+          setQuery(e.target.value)
+          setShow(true)
+        }}
+        placeholder={placeholder}
+        onFocus={() => setShow(true)}
+        autoComplete="off"
+      />
+      {show && suggestions.length > 0 && (
+        <ul className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md border bg-white shadow-lg">
+          {suggestions.map(s => (
+            <li
+              key={s.display_name}
+              className="cursor-pointer px-2 py-1 text-sm hover:bg-gray-100"
+              onMouseDown={() => handleSelect(s)}
+            >
+              {s.display_name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/household/EditHouseholdForm.tsx
+++ b/src/components/household/EditHouseholdForm.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 import { Input } from '@/components/ui/input'
+import { AddressAutocomplete } from '@/components/AddressAutocomplete'
+import { haversineDistance } from '@/lib/distance'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
@@ -53,6 +55,8 @@ export const EditHouseholdForm = ({ household, onSubmit, onCancel }: EditHouseho
         ? String(household.furniture_volume)
         : ''
   })
+  const [oldCoords, setOldCoords] = useState<{ lat: number; lon: number } | null>(null)
+  const [newCoords, setNewCoords] = useState<{ lat: number; lon: number } | null>(null)
 
   const updateField = (field: string, value: string) => {
     setForm(prev => ({ ...prev, [field]: value }))
@@ -63,6 +67,18 @@ export const EditHouseholdForm = ({ household, onSubmit, onCancel }: EditHouseho
     const num = Number(value)
     return Number.isNaN(num) ? null : num
   }
+
+  const distanceKm =
+    oldCoords && newCoords
+      ? Math.round(
+          haversineDistance(
+            oldCoords.lat,
+            oldCoords.lon,
+            newCoords.lat,
+            newCoords.lon
+          )
+        )
+      : null
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -169,20 +185,23 @@ export const EditHouseholdForm = ({ household, onSubmit, onCancel }: EditHouseho
 
       <div className="space-y-2">
         <Label htmlFor="edit-old">Aktuelle Adresse (optional)</Label>
-        <Input
-          id="edit-old"
+        <AddressAutocomplete
           value={form.old_address}
-          onChange={(e) => updateField('old_address', e.target.value)}
+          onChange={(val) => updateField('old_address', val)}
+          onSelect={setOldCoords}
         />
       </div>
 
       <div className="space-y-2">
         <Label htmlFor="edit-new">Neue Adresse</Label>
-        <Input
-          id="edit-new"
+        <AddressAutocomplete
           value={form.new_address}
-          onChange={(e) => updateField('new_address', e.target.value)}
+          onChange={(val) => updateField('new_address', val)}
+          onSelect={setNewCoords}
         />
+        {distanceKm != null && (
+          <p className="text-sm text-gray-600 mt-1">Entfernung ca. {distanceKm} km</p>
+        )}
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { AddressAutocomplete } from '@/components/AddressAutocomplete'
+import { haversineDistance } from '@/lib/distance'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Badge } from '@/components/ui/badge'
@@ -52,9 +54,22 @@ export const OnboardingFlow = ({ onComplete, onSkip }: OnboardingFlowProps) => {
     furnitureVolume: 0,
     members: []
   })
+  const [oldCoords, setOldCoords] = useState<{ lat: number; lon: number } | null>(null)
+  const [newCoords, setNewCoords] = useState<{ lat: number; lon: number } | null>(null)
 
   const totalSteps = 5
   const progress = (currentStep / totalSteps) * 100
+  const distanceKm =
+    oldCoords && newCoords
+      ? Math.round(
+          haversineDistance(
+            oldCoords.lat,
+            oldCoords.lon,
+            newCoords.lat,
+            newCoords.lon
+          )
+        )
+      : null
 
   const updateData = (updates: Partial<OnboardingData>) => {
     setData(prev => ({ ...prev, ...updates }))
@@ -292,22 +307,27 @@ export const OnboardingFlow = ({ onComplete, onSkip }: OnboardingFlowProps) => {
 
                 <div>
                   <Label htmlFor="oldAddress">Aktuelle Adresse (optional)</Label>
-                  <Input
-                    id="oldAddress"
+                  <AddressAutocomplete
                     value={data.oldAddress}
-                    onChange={(e) => updateData({ oldAddress: e.target.value })}
+                    onChange={(val) => updateData({ oldAddress: val })}
+                    onSelect={setOldCoords}
                     placeholder="Straße, Hausnummer, Ort"
                   />
                 </div>
 
                 <div>
                   <Label htmlFor="newAddress">Neue Adresse</Label>
-                  <Input
-                    id="newAddress"
+                  <AddressAutocomplete
                     value={data.newAddress}
-                    onChange={(e) => updateData({ newAddress: e.target.value })}
+                    onChange={(val) => updateData({ newAddress: val })}
+                    onSelect={setNewCoords}
                     placeholder="Straße, Hausnummer, Ort"
                   />
+                  {distanceKm != null && (
+                    <p className="text-sm text-gray-600 mt-1">
+                      Entfernung ca. {distanceKm} km
+                    </p>
+                  )}
                 </div>
 
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/src/lib/distance.ts
+++ b/src/lib/distance.ts
@@ -1,0 +1,18 @@
+export function haversineDistance(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number
+): number {
+  const R = 6371
+  const toRad = (deg: number) => (deg * Math.PI) / 180
+  const dLat = toRad(lat2 - lat1)
+  const dLon = toRad(lon2 - lon1)
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) *
+      Math.cos(toRad(lat2)) *
+      Math.sin(dLon / 2) ** 2
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  return R * c
+}


### PR DESCRIPTION
## Summary
- add `AddressAutocomplete` component using Nominatim
- compute haversine distance between two addresses
- integrate autocomplete & distance hint in onboarding flow and edit household form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685ee3eac9288320ad36677a30c6be24