### PR TITLE
Add address validation and hooks

### DIFF
--- a/src/components/AddressAutocomplete.tsx
+++ b/src/components/AddressAutocomplete.tsx
@@ -1,0 +1,187 @@
+import { useState, useEffect, useRef } from 'react'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+
+interface Suggestion {
+  display_name: string
+  lat: string
+  lon: string
+}
+
+interface AddressAutocompleteProps {
+  value: string
+  onChange: (value: string) => void
+  onSelect?: (s: { lat: number; lon: number }) => void
+  placeholder?: string
+  className?: string
+}
+
+export const AddressAutocomplete = ({
+  value,
+  onChange,
+  onSelect,
+  placeholder,
+  className
+}: AddressAutocompleteProps) => {
+  const [query, setQuery] = useState(value)
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([])
+  const [show, setShow] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [highlight, setHighlight] = useState(-1)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const lastFetchRef = useRef(0)
+
+  useEffect(() => {
+    setQuery(value)
+  }, [value])
+
+  useEffect(() => {
+    if (query.length < 3) {
+      setSuggestions([])
+      setError(null)
+      return
+    }
+
+    const now = Date.now()
+    if (now - lastFetchRef.current < 1000) {
+      return
+    }
+    lastFetchRef.current = now
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => {
+      setLoading(true)
+      setError(null)
+      const requestTimeout = setTimeout(() => controller.abort(), 5000)
+      fetch(
+        `https://nominatim.openstreetmap.org/search?format=jsonv2&q=${encodeURIComponent(
+          query
+        )}`,
+        {
+          signal: controller.signal,
+          headers: {
+            'Accept-Language': 'de',
+            'User-Agent': 'muutto-umzug/1.0 (+https://www.muutto.xyz)'
+          }
+        }
+      )
+        .then(res => res.json())
+        .then((data: unknown) => {
+          if (!Array.isArray(data)) {
+            throw new Error('Invalid response')
+          }
+          const valid = data.filter(
+            (d): d is Suggestion =>
+              d &&
+              typeof d.display_name === 'string' &&
+              typeof d.lat === 'string' &&
+              typeof d.lon === 'string'
+          )
+          setSuggestions(valid.slice(0, 5))
+        })
+        .catch(err => {
+          if (err.name === 'AbortError') {
+            console.warn('Address lookup timed out')
+            setError('Adresssuche hat zu lange gedauert')
+          } else {
+            console.error('Address lookup failed', err)
+            setError('Adressen konnten nicht geladen werden')
+          }
+          setSuggestions([])
+        })
+        .finally(() => {
+          clearTimeout(requestTimeout)
+          setLoading(false)
+        })
+    }, 300)
+
+    return () => {
+      clearTimeout(timeout)
+      controller.abort()
+    }
+  }, [query])
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setShow(false)
+      }
+    }
+    document.addEventListener('click', handleClick)
+    return () => document.removeEventListener('click', handleClick)
+  }, [])
+
+  const handleSelect = (s: Suggestion) => {
+    const lat = parseFloat(s.lat)
+    const lon = parseFloat(s.lon)
+    if (Number.isNaN(lat) || Number.isNaN(lon)) {
+      console.error('Invalid coordinates in suggestion', s)
+      setError('Ungültige Koordinaten')
+      return
+    }
+    onChange(s.display_name)
+    onSelect?.({ lat, lon })
+    setShow(false)
+  }
+
+  return (
+    <div ref={containerRef} className={cn('relative', className)}>
+      <Input
+        value={value}
+        onChange={e => {
+          onChange(e.target.value)
+          setQuery(e.target.value)
+          setShow(true)
+        }}
+        placeholder={placeholder}
+        onFocus={() => setShow(true)}
+        onKeyDown={e => {
+          if (!show) return
+          if (e.key === 'ArrowDown') {
+            e.preventDefault()
+            setHighlight(h => (h + 1) % suggestions.length)
+          } else if (e.key === 'ArrowUp') {
+            e.preventDefault()
+            setHighlight(h => (h - 1 + suggestions.length) % suggestions.length)
+          } else if (e.key === 'Enter') {
+            if (highlight >= 0 && suggestions[highlight]) {
+              e.preventDefault()
+              handleSelect(suggestions[highlight])
+            }
+          }
+        }}
+        autoComplete="off"
+      />
+      {error && (
+        <p className="text-sm text-red-500 mt-1" role="alert">
+          {error}
+        </p>
+      )}
+      {show && (suggestions.length > 0 || loading) && (
+        <ul
+          role="listbox"
+          className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md border bg-white shadow-lg"
+        >
+          {loading && (
+            <li className="px-2 py-1 text-sm text-gray-500">Lade...</li>
+          )}
+          {suggestions.map((s, i) => (
+            <li
+              role="option"
+              aria-selected={i === highlight}
+              key={s.display_name}
+              className={cn(
+                'cursor-pointer px-2 py-1 text-sm hover:bg-gray-100',
+                i === highlight && 'bg-gray-100'
+              )}
+              onClick={() => handleSelect(s)}
+            >
+              {s.display_name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/components/household/EditHouseholdForm.tsx
+++ b/src/components/household/EditHouseholdForm.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 import { Input } from '@/components/ui/input'
+import { AddressAutocomplete } from '@/components/AddressAutocomplete'
+import { useDistanceCalculation } from '@/hooks/useDistanceCalculation'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
@@ -53,9 +55,27 @@ export const EditHouseholdForm = ({ household, onSubmit, onCancel }: EditHouseho
         ? String(household.furniture_volume)
         : ''
   })
+  const {
+    oldCoords,
+    newCoords,
+    setOldCoords,
+    setNewCoords,
+    distanceKm,
+    distanceFact
+  } = useDistanceCalculation()
+  const [oldAddressError, setOldAddressError] = useState<string | null>(null)
+  const [newAddressError, setNewAddressError] = useState<string | null>(null)
 
   const updateField = (field: string, value: string) => {
     setForm(prev => ({ ...prev, [field]: value }))
+    if (field === 'old_address') {
+      setOldCoords(null)
+      setOldAddressError(null)
+    }
+    if (field === 'new_address') {
+      setNewCoords(null)
+      setNewAddressError(null)
+    }
   }
 
   const parseNumber = (value: string): number | null => {
@@ -64,19 +84,44 @@ export const EditHouseholdForm = ({ household, onSubmit, onCancel }: EditHouseho
     return Number.isNaN(num) ? null : num
   }
 
+  const handleOldSelect = (coords?: { lat: number; lon: number }) => {
+    if (!coords || Number.isNaN(coords.lat) || Number.isNaN(coords.lon)) {
+      setOldAddressError('Ungültige Koordinaten')
+      setOldCoords(null)
+      return
+    }
+    setOldCoords(coords)
+    setOldAddressError(null)
+  }
+
+  const handleNewSelect = (coords?: { lat: number; lon: number }) => {
+    if (!coords || Number.isNaN(coords.lat) || Number.isNaN(coords.lon)) {
+      setNewAddressError('Ungültige Koordinaten')
+      setNewCoords(null)
+      return
+    }
+    setNewCoords(coords)
+    setNewAddressError(null)
+  }
+
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-      onSubmit({
-        ...form,
-        household_size: parseNumber(form.household_size),
-        children_count: parseNumber(form.children_count),
-        pets_count: parseNumber(form.pets_count),
-        postal_code: form.postal_code.trim() ? form.postal_code : null,
-        living_space: parseNumber(form.living_space),
-        rooms: parseNumber(form.rooms),
-        furniture_volume: parseNumber(form.furniture_volume),
-        old_address: form.old_address || null,
-      new_address: form.new_address || null
+    onSubmit({
+      ...form,
+      household_size: parseNumber(form.household_size),
+      children_count: parseNumber(form.children_count),
+      pets_count: parseNumber(form.pets_count),
+      postal_code: form.postal_code.trim() ? form.postal_code : null,
+      living_space: parseNumber(form.living_space),
+      rooms: parseNumber(form.rooms),
+      furniture_volume: parseNumber(form.furniture_volume),
+      old_address: form.old_address || null,
+      new_address: form.new_address || null,
+      old_lat: oldCoords?.lat ?? null,
+      old_lon: oldCoords?.lon ?? null,
+      new_lat: newCoords?.lat ?? null,
+      new_lon: newCoords?.lon ?? null
     })
   }
 
@@ -169,20 +214,35 @@ export const EditHouseholdForm = ({ household, onSubmit, onCancel }: EditHouseho
 
       <div className="space-y-2">
         <Label htmlFor="edit-old">Aktuelle Adresse (optional)</Label>
-        <Input
-          id="edit-old"
+        <AddressAutocomplete
           value={form.old_address}
-          onChange={(e) => updateField('old_address', e.target.value)}
+          onChange={(val) => updateField('old_address', val)}
+          onSelect={handleOldSelect}
         />
+        {oldAddressError && (
+          <p className="text-sm text-red-500" role="alert">{oldAddressError}</p>
+        )}
       </div>
 
       <div className="space-y-2">
         <Label htmlFor="edit-new">Neue Adresse</Label>
-        <Input
-          id="edit-new"
+        <AddressAutocomplete
           value={form.new_address}
-          onChange={(e) => updateField('new_address', e.target.value)}
+          onChange={(val) => updateField('new_address', val)}
+          onSelect={handleNewSelect}
         />
+        {newAddressError && (
+          <p className="text-sm text-red-500" role="alert">{newAddressError}</p>
+        )}
+        {distanceKm != null && distanceFact != null && (
+          <p
+            className="text-sm text-gray-600 mt-1"
+            role="status"
+            aria-live="polite"
+          >
+            Entfernung ca. {distanceKm} km – {distanceFact}
+          </p>
+        )}
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -3,6 +3,8 @@ import { useState } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { AddressAutocomplete } from '@/components/AddressAutocomplete'
+import { useDistanceCalculation } from '@/hooks/useDistanceCalculation'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Badge } from '@/components/ui/badge'
@@ -52,6 +54,8 @@ export const OnboardingFlow = ({ onComplete, onSkip }: OnboardingFlowProps) => {
     furnitureVolume: 0,
     members: []
   })
+  const { setOldCoords, setNewCoords, distanceKm, distanceFact } =
+    useDistanceCalculation()
 
   const totalSteps = 5
   const progress = (currentStep / totalSteps) * 100
@@ -292,22 +296,27 @@ export const OnboardingFlow = ({ onComplete, onSkip }: OnboardingFlowProps) => {
 
                 <div>
                   <Label htmlFor="oldAddress">Aktuelle Adresse (optional)</Label>
-                  <Input
-                    id="oldAddress"
+                  <AddressAutocomplete
                     value={data.oldAddress}
-                    onChange={(e) => updateData({ oldAddress: e.target.value })}
+                    onChange={(val) => updateData({ oldAddress: val })}
+                    onSelect={setOldCoords}
                     placeholder="Straße, Hausnummer, Ort"
                   />
                 </div>
 
                 <div>
                   <Label htmlFor="newAddress">Neue Adresse</Label>
-                  <Input
-                    id="newAddress"
+                  <AddressAutocomplete
                     value={data.newAddress}
-                    onChange={(e) => updateData({ newAddress: e.target.value })}
+                    onChange={(val) => updateData({ newAddress: val })}
+                    onSelect={setNewCoords}
                     placeholder="Straße, Hausnummer, Ort"
                   />
+                  {distanceKm != null && (
+                    <p className="text-sm text-gray-600 mt-1">
+                      Entfernung ca. {distanceKm} km – {distanceFact}
+                    </p>
+                  )}
                 </div>
 
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/src/hooks/useDistanceCalculation.ts
+++ b/src/hooks/useDistanceCalculation.ts
@@ -1,0 +1,31 @@
+import { useState, useMemo } from 'react'
+import { haversineDistance } from '@/lib/distance'
+import { getDistanceFunFact } from '@/lib/funfacts'
+
+export function useDistanceCalculation() {
+  const [oldCoords, setOldCoords] = useState<{ lat: number; lon: number } | null>(null)
+  const [newCoords, setNewCoords] = useState<{ lat: number; lon: number } | null>(null)
+
+  const distanceKm = useMemo(() => {
+    if (oldCoords && newCoords) {
+      return Math.round(
+        haversineDistance(
+          oldCoords.lat,
+          oldCoords.lon,
+          newCoords.lat,
+          newCoords.lon
+        )
+      )
+    }
+    return null
+  }, [oldCoords, newCoords])
+
+  const distanceFact = useMemo(() => {
+    if (distanceKm != null) {
+      return getDistanceFunFact(distanceKm)
+    }
+    return null
+  }, [distanceKm])
+
+  return { oldCoords, newCoords, setOldCoords, setNewCoords, distanceKm, distanceFact }
+}

--- a/src/lib/distance.ts
+++ b/src/lib/distance.ts
@@ -1,0 +1,32 @@
+export function haversineDistance(
+  lat1: number,
+  lon1: number,
+  lat2: number,
+  lon2: number
+): number {
+  const isValidLat = (lat: number) =>
+    Number.isFinite(lat) && lat >= -90 && lat <= 90
+  const isValidLon = (lon: number) =>
+    Number.isFinite(lon) && lon >= -180 && lon <= 180
+
+  if (
+    !isValidLat(lat1) ||
+    !isValidLat(lat2) ||
+    !isValidLon(lon1) ||
+    !isValidLon(lon2)
+  ) {
+    throw new Error('Invalid coordinates')
+  }
+
+  const R = 6371
+  const toRad = (deg: number) => (deg * Math.PI) / 180
+  const dLat = toRad(lat2 - lat1)
+  const dLon = toRad(lon2 - lon1)
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) *
+      Math.cos(toRad(lat2)) *
+      Math.sin(dLon / 2) ** 2
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  return R * c
+}

--- a/src/lib/funfacts.ts
+++ b/src/lib/funfacts.ts
@@ -1,0 +1,11 @@
+export function getDistanceFunFact(distanceKm: number): string {
+  const soccerFields = Math.round((distanceKm * 1000) / 105)
+  const araKmPerYear = 5000
+
+  if (distanceKm >= 1000) {
+    const years = Math.round((distanceKm / araKmPerYear) * 10) / 10
+    return `Das ist etwa die Strecke, die ein Ara in ${years} Jahren zuruecklegt!`
+  }
+
+  return `Das sind ungefaehr ${soccerFields} Fussballfelder.`
+}


### PR DESCRIPTION
## Summary
- create distance calculation hook
- improve AddressAutocomplete UX with rate limiting and errors
- update household form to handle coordinate validation and accessibility
- add fetch timeout and user-agent header for Nominatim
- validate coordinate inputs and selection parsing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685ee3eac9288320ad36677a30c6be24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an address autocomplete input with real-time suggestions for address fields, enhancing user experience in forms and onboarding.
  * Introduced automatic calculation and display of the distance between two selected addresses, including a fun fact related to the distance.

* **Bug Fixes**
  * Improved error handling and validation for address inputs, displaying user-friendly error messages for invalid or unrecognized addresses.

* **Enhancements**
  * Enabled keyboard navigation and accessibility improvements for address selection and suggestion lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->