### PR TITLE
Fix missing household fields in types

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -110,6 +110,11 @@ export type Database = {
           name: string
           pets_count: number
           postal_code: string | null
+          old_address: string | null
+          new_address: string | null
+          living_space: number | null
+          rooms: number | null
+          furniture_volume: number | null
           property_type: Database["public"]["Enums"]["property_type"]
           updated_at: string
         }
@@ -124,6 +129,11 @@ export type Database = {
           name: string
           pets_count?: number
           postal_code?: string | null
+          old_address?: string | null
+          new_address?: string | null
+          living_space?: number | null
+          rooms?: number | null
+          furniture_volume?: number | null
           property_type: Database["public"]["Enums"]["property_type"]
           updated_at?: string
         }
@@ -138,6 +148,11 @@ export type Database = {
           name?: string
           pets_count?: number
           postal_code?: string | null
+          old_address?: string | null
+          new_address?: string | null
+          living_space?: number | null
+          rooms?: number | null
+          furniture_volume?: number | null
           property_type?: Database["public"]["Enums"]["property_type"]
           updated_at?: string
         }


### PR DESCRIPTION
## Summary
- add move-related columns to Supabase `households` definitions

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fbc87a7008320aa5d96d056e38cb8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional household details, including old and new addresses, living space, number of rooms, and furniture volume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->