### PR TITLE
Add task view and WIP modules

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -13,14 +13,21 @@ import { usePendingInvitations } from '@/hooks/usePendingInvitations'
 import { HouseholdOverview } from './household/HouseholdOverview'
 import { MemberManagement } from './household/MemberManagement'
 import { EditHouseholdForm } from './household/EditHouseholdForm'
+import { TaskList } from './TaskList'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { AuthPage } from './auth/AuthPage'
 import { useToast } from '@/hooks/use-toast'
 import { ExtendedHousehold } from '@/types/household'
 import { APP_CONFIG, getRandomTip } from '@/config/app'
 import { calculateHouseholdProgress, getProgressColor } from '@/utils/progressCalculator'
+import { WorkInProgressCard } from './WorkInProgressCard'
 
-type ViewMode = 'dashboard' | 'household-overview' | 'member-management' | 'onboarding'
+type ViewMode =
+  | 'dashboard'
+  | 'household-overview'
+  | 'member-management'
+  | 'task-list'
+  | 'onboarding'
 
 export const Dashboard = () => {
   const { user, signOut, loading: authLoading } = useAuth()
@@ -129,6 +136,11 @@ export const Dashboard = () => {
     setViewMode('household-overview')
   }
 
+  const openTaskList = (household: ExtendedHousehold) => {
+    setActiveHousehold(household)
+    setViewMode('task-list')
+  }
+
   const showMemberManagement = () => {
     setViewMode('member-management')
   }
@@ -175,6 +187,7 @@ export const Dashboard = () => {
             household={activeHousehold}
             onManageMembers={showMemberManagement}
             onEditHousehold={() => setShowEditDialog(true)}
+            onViewTasks={() => openTaskList(activeHousehold)}
           />
 
           <Dialog open={showEditDialog} onOpenChange={setShowEditDialog}>
@@ -211,6 +224,12 @@ export const Dashboard = () => {
           />
         </div>
       </div>
+    )
+  }
+
+  if (viewMode === 'task-list' && activeHousehold) {
+    return (
+      <TaskList household={activeHousehold} onBack={() => setViewMode('household-overview')} />
     )
   }
 
@@ -353,13 +372,22 @@ export const Dashboard = () => {
                             {household.children_count > 0 && `, ${household.children_count} Kinder`}
                             {household.pets_count > 0 && `, ${household.pets_count} Haustiere`}
                           </div>
-                          <Button 
-                            size="sm" 
-                            onClick={() => openHousehold(household)}
-                            className="bg-blue-600 hover:bg-blue-700"
-                          >
-                            Öffnen
-                          </Button>
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => openTaskList(household)}
+                            >
+                              Aufgaben
+                            </Button>
+                            <Button
+                              size="sm"
+                              onClick={() => openHousehold(household)}
+                              className="bg-blue-600 hover:bg-blue-700"
+                            >
+                              Öffnen
+                            </Button>
+                          </div>
                         </div>
                       </div>
                     </CardContent>
@@ -379,6 +407,13 @@ export const Dashboard = () => {
             <p>{dailyTip}</p>
           </CardContent>
         </Card>
+
+        {/* Modules Overview */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8">
+          <WorkInProgressCard title="Verträge" icon="💳" />
+          <WorkInProgressCard title="Inventar" icon="📦" />
+          <WorkInProgressCard title="Rechtliches" icon="⚖️" />
+        </div>
       </div>
     </div>
   )

--- a/src/components/WorkInProgressCard.tsx
+++ b/src/components/WorkInProgressCard.tsx
@@ -1,0 +1,23 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+
+interface WorkInProgressCardProps {
+  title: string
+  icon?: string
+}
+
+export const WorkInProgressCard = ({ title, icon }: WorkInProgressCardProps) => (
+  <Card className="bg-white shadow-lg relative">
+    <CardHeader>
+      <CardTitle className="flex items-center gap-2">
+        {icon && <span>{icon}</span>}
+        {title}
+      </CardTitle>
+    </CardHeader>
+    <CardContent>
+      <div className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-75">
+        <Badge variant="secondary">Work in Progress</Badge>
+      </div>
+    </CardContent>
+  </Card>
+)

--- a/src/components/WorkInProgressCard.tsx
+++ b/src/components/WorkInProgressCard.tsx
@@ -15,7 +15,7 @@ export const WorkInProgressCard = ({ title, icon }: WorkInProgressCardProps) => 
       </CardTitle>
     </CardHeader>
     <CardContent>
-      <div className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-75">
+      <div className="flex items-center justify-center p-4 bg-gray-50 bg-opacity-90 rounded" aria-label="Feature under development">
         <Badge variant="secondary">Work in Progress</Badge>
       </div>
     </CardContent>

--- a/src/components/household/HouseholdOverview.tsx
+++ b/src/components/household/HouseholdOverview.tsx
@@ -12,12 +12,14 @@ interface HouseholdOverviewProps {
   household: ExtendedHousehold
   onManageMembers: () => void
   onEditHousehold: () => void
+  onViewTasks: () => void
 }
 
-export const HouseholdOverview = ({ 
-  household, 
-  onManageMembers, 
-  onEditHousehold 
+export const HouseholdOverview = ({
+  household,
+  onManageMembers,
+  onEditHousehold,
+  onViewTasks
 }: HouseholdOverviewProps) => {
   const progressMetrics = calculateHouseholdProgress(household.move_date, 0, 4)
   const progressColor = getProgressColor(progressMetrics.overall)
@@ -169,6 +171,18 @@ export const HouseholdOverview = ({
             </span>
           </div>
           {/* Quick member avatars could be added here */}
+        </CardContent>
+      </Card>
+
+      {/* Tasks */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Aufgaben</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Button onClick={onViewTasks} className="bg-blue-600 hover:bg-blue-700">
+            Zur Aufgabenliste
+          </Button>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- show Work in Progress cards on dashboard
- allow opening task list from dashboard
- add tasks button in household overview

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_685fbf66721083209d1f215a0391bd46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "task-list" view mode to the dashboard, allowing users to view tasks for each household.
  * Introduced a new "Aufgaben" (Tasks) button on each household card to access the task list directly.
  * Added a "Zur Aufgabenliste" (To the task list) button in the household overview for easier task navigation.
  * Introduced "Work in Progress" cards for "Verträge", "Inventar", and "Rechtliches" in a new dashboard section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->