### PR TITLE
Use modular dashboard by default

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,15 +1,9 @@
-import { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
-import { Dashboard } from '@/components/Dashboard';
 import { ModularDashboard } from '@/components/dashboard/ModularDashboard';
-import { Button } from '@/components/ui/button';
-import { Switch } from '@/components/ui/switch';
-import { Label } from '@/components/ui/label';
 import { AuthPage } from '@/components/auth/AuthPage';
 
 const Index = () => {
   const { user, loading } = useAuth();
-  const [useModularDashboard, setUseModularDashboard] = useState(false);
 
   if (loading) {
     return (
@@ -28,19 +22,7 @@ const Index = () => {
 
   return (
     <div>
-      {/* Dashboard Toggle */}
-      <div className="fixed top-4 right-4 z-50 bg-white p-2 rounded-lg shadow-lg flex items-center gap-2">
-        <Label htmlFor="dashboard-toggle" className="text-xs">
-          Modulares Dashboard
-        </Label>
-        <Switch
-          id="dashboard-toggle"
-          checked={useModularDashboard}
-          onCheckedChange={setUseModularDashboard}
-        />
-      </div>
-
-      {useModularDashboard ? <ModularDashboard /> : <Dashboard />}
+      <ModularDashboard />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- drop old dashboard toggle in `Index`
- make modular dashboard default and handle onboarding when no households exist

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68609303258c8320b22c870c019a4898

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an onboarding flow for users without households, including a guided setup and success confirmation.
  * Added a welcome card prompting new users to start onboarding when no households exist.

* **Refactor**
  * Simplified the dashboard page to always display the new modular dashboard, removing the previous toggle option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->