### PR TITLE
Use dynamic data for reminders and progress

### DIFF
--- a/src/components/dashboard/ModularDashboard.tsx
+++ b/src/components/dashboard/ModularDashboard.tsx
@@ -56,6 +56,7 @@ import { ReminderSystem } from '@/components/reminders/ReminderSystem'
 import { MovingInsights } from '@/components/insights/MovingInsights'
 import { OnboardingFlowWithDrafts } from '@/components/onboarding/OnboardingFlowWithDrafts'
 import { OnboardingSuccess } from '@/components/onboarding/OnboardingSuccess'
+import { useTasks } from '@/hooks/useTasks'
 
 // Define module types
 export interface DashboardModule {
@@ -139,6 +140,7 @@ export const ModularDashboard = () => {
   const { households, loading, createHousehold, addMembers } = useHouseholds()
   const { toast } = useToast()
   const [activeHousehold, setActiveHousehold] = useState<ExtendedHousehold | null>(null)
+  const { tasks } = useTasks(activeHousehold?.id)
   const [modules, setModules] = useState<DashboardModule[]>([])
   const [activeTab, setActiveTab] = useState('dashboard')
   const [viewMode, setViewMode] = useState<'dashboard' | 'onboarding' | 'onboarding-success'>('dashboard')
@@ -654,6 +656,13 @@ export const ModularDashboard = () => {
   }
 
   const nextDeadline = getDaysUntilMove(activeHousehold.move_date)
+  const completedTasks = tasks.filter(t => t.completed).length
+  const progressMetrics = calculateHouseholdProgress(
+    activeHousehold.move_date,
+    completedTasks,
+    tasks.length
+  )
+  const openTasks = tasks.length - completedTasks
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
@@ -712,7 +721,7 @@ export const ModularDashboard = () => {
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold text-green-600">
-                {calculateHouseholdProgress(activeHousehold.move_date).overall}%
+                {progressMetrics.overall}%
               </div>
             </CardContent>
           </Card>
@@ -723,7 +732,7 @@ export const ModularDashboard = () => {
               <CheckCircle className="h-4 w-4 text-orange-600" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold text-orange-600">12</div>
+              <div className="text-2xl font-bold text-orange-600">{openTasks}</div>
             </CardContent>
           </Card>
         </div>

--- a/src/components/household/HouseholdOverview.tsx
+++ b/src/components/household/HouseholdOverview.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
 import { ExtendedHousehold } from '@/types/household'
 import { calculateHouseholdProgress, getProgressColor } from '@/utils/progressCalculator'
+import { useTasks } from '@/hooks/useTasks'
 import { PROPERTY_TYPES } from '@/config/app'
 import { Users, Calendar, MapPin, Home, Settings, Square } from 'lucide-react'
 
@@ -21,7 +22,13 @@ export const HouseholdOverview = ({
   onEditHousehold,
   onViewTasks
 }: HouseholdOverviewProps) => {
-  const progressMetrics = calculateHouseholdProgress(household.move_date, 0, 4)
+  const { tasks } = useTasks(household.id)
+  const completedTasks = tasks.filter(t => t.completed).length
+  const progressMetrics = calculateHouseholdProgress(
+    household.move_date,
+    completedTasks,
+    tasks.length
+  )
   const progressColor = getProgressColor(progressMetrics.overall)
   const propertyType = PROPERTY_TYPES.find(pt => pt.key === household.property_type)
 

--- a/src/components/insights/MovingInsights.tsx
+++ b/src/components/insights/MovingInsights.tsx
@@ -3,6 +3,7 @@ import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
 import { ExtendedHousehold } from '@/types/household'
 import { calculateHouseholdProgress } from '@/utils/progressCalculator'
+import { useTasks } from '@/hooks/useTasks'
 import { 
   TrendingUp, 
   Calendar, 
@@ -20,7 +21,13 @@ interface MovingInsightsProps {
 }
 
 export const MovingInsights = ({ household, className }: MovingInsightsProps) => {
-  const progress = calculateHouseholdProgress(household.move_date, 0, 10)
+  const { tasks } = useTasks(household.id)
+  const completedTasks = tasks.filter(t => t.completed).length
+  const progress = calculateHouseholdProgress(
+    household.move_date,
+    completedTasks,
+    tasks.length
+  )
   
   const getDaysUntilMove = () => {
     const today = new Date()


### PR DESCRIPTION
## Summary
- fetch reminders from Supabase tasks instead of using mock data
- compute household progress based on tasks in several components
- show progress and open task count in modular dashboard
- fetch progress for all households in dashboard overview

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6861004d40788320b2de6003930f0f46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard and related components now display real-time progress and open tasks based on actual task completion data.
  * Household cards provide detailed progress metrics, move date urgency, household size, children, and pets information.
  * Reminders are now generated dynamically from real tasks instead of static data.

* **Refactor**
  * Progress calculations throughout the dashboard and insights are now dynamically based on backend task data, improving accuracy and consistency.
  * Household card rendering is centralized for better modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->