### PR TITLE
Fix dashboard modules initialization

### DIFF
--- a/src/hooks/useDashboardModules.ts
+++ b/src/hooks/useDashboardModules.ts
@@ -58,6 +58,14 @@ export const useDashboardModules = (initialModules: DashboardModule[]) => {
     }
   }, []);
 
+  // Apply initial modules when they change (e.g., after async loading)
+  useEffect(() => {
+    if (initialModules.length && modules.length === 0) {
+      setModules(initialModules);
+      setModulePositions({});
+    }
+  }, [initialModules, modules.length]);
+
   // Save modules to localStorage when they change
   useEffect(() => {
     if (modules.length > 0) {


### PR DESCRIPTION
## Summary
- update dashboard hook to apply initial modules on change and reset positions
- ensure effect dependencies include `modules.length` to avoid stale closures

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68611d96a0c08320b78de0fd1e512e79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of dashboard modules when the initial set of modules changes after loading, ensuring the displayed modules update correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->