### PR TITLE
Improve mobile dashboard layout

### DIFF
--- a/src/components/dashboard/MagneticDraggableModule.tsx
+++ b/src/components/dashboard/MagneticDraggableModule.tsx
@@ -1,10 +1,12 @@
 
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { GripVertical } from 'lucide-react';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
+import { GripVertical, ChevronDown, ChevronUp } from 'lucide-react';
 import { DashboardModule } from './ModularDashboard';
 
 interface GridPosition {
@@ -47,6 +49,8 @@ export const MagneticDraggableModule = ({
     gridRow: position ? `${position.y + 1} / span ${position.height}` : 'auto',
   };
 
+  const [open, setOpen] = useState(true);
+
   // Handle drag end to update position
   const handleDragEnd = () => {
     if (transform && position) {
@@ -63,8 +67,8 @@ export const MagneticDraggableModule = ({
   };
 
   return (
-    <div 
-      ref={setNodeRef} 
+    <div
+      ref={setNodeRef}
       style={style}
       className={`
         transition-all duration-200 ease-out
@@ -74,48 +78,57 @@ export const MagneticDraggableModule = ({
       onMouseUp={handleDragEnd}
       onTouchEnd={handleDragEnd}
     >
-      <Card className="bg-white h-full border-2 border-transparent hover:border-blue-200 transition-colors">
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <div className="flex items-center gap-2">
-            <div 
-              className="cursor-move touch-none p-1 rounded hover:bg-gray-100 transition-colors" 
-              {...attributes} 
-              {...listeners}
-            >
-              <GripVertical className="h-4 w-4 text-gray-400 hover:text-gray-600" />
-            </div>
-            <CardTitle className="text-lg flex items-center gap-2">
-              {module.icon}
-              {module.title}
-            </CardTitle>
-          </div>
-          <div className="flex items-center gap-2">
-            <Switch 
-              checked={module.enabled} 
-              onCheckedChange={() => onToggle(module.id)} 
-              id={`toggle-${module.id}`}
-            />
-            <Label htmlFor={`toggle-${module.id}`} className="text-xs text-gray-500">
-              {module.enabled ? 'Aktiv' : 'Inaktiv'}
-            </Label>
-          </div>
-        </CardHeader>
-        <CardContent>
-          {module.enabled ? (
-            module.component
-          ) : (
-            <div className="flex flex-col items-center justify-center py-8 text-center text-gray-500">
-              <p className="mb-4">Dieses Modul ist deaktiviert</p>
-              <button 
-                className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
-                onClick={() => onToggle(module.id)}
+      <Collapsible open={open} onOpenChange={setOpen} className="h-full">
+        <Card className="bg-white h-full border-2 border-transparent hover:border-blue-200 transition-colors flex flex-col">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <div className="flex items-center gap-2">
+              <div
+                className="cursor-move touch-none p-1 rounded hover:bg-gray-100 transition-colors"
+                {...attributes}
+                {...listeners}
               >
-                Aktivieren
-              </button>
+                <GripVertical className="h-4 w-4 text-gray-400 hover:text-gray-600" />
+              </div>
+              <CardTitle className="text-lg flex items-center gap-2">
+                {module.icon}
+                {module.title}
+              </CardTitle>
             </div>
-          )}
-        </CardContent>
-      </Card>
+            <div className="flex items-center gap-2">
+              <Switch
+                checked={module.enabled}
+                onCheckedChange={() => onToggle(module.id)}
+                id={`toggle-${module.id}`}
+              />
+              <Label htmlFor={`toggle-${module.id}`} className="text-xs text-gray-500">
+                {module.enabled ? 'Aktiv' : 'Inaktiv'}
+              </Label>
+              <CollapsibleTrigger asChild className="sm:hidden">
+                <button className="p-1 rounded hover:bg-gray-100">
+                  {open ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+                </button>
+              </CollapsibleTrigger>
+            </div>
+          </CardHeader>
+          <CollapsibleContent className="sm:block">
+            <CardContent>
+              {module.enabled ? (
+                module.component
+              ) : (
+                <div className="flex flex-col items-center justify-center py-8 text-center text-gray-500">
+                  <p className="mb-4">Dieses Modul ist deaktiviert</p>
+                  <button
+                    className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
+                    onClick={() => onToggle(module.id)}
+                  >
+                    Aktivieren
+                  </button>
+                </div>
+              )}
+            </CardContent>
+          </CollapsibleContent>
+        </Card>
+      </Collapsible>
     </div>
   );
 };

--- a/src/components/dashboard/ModularDashboard.tsx
+++ b/src/components/dashboard/ModularDashboard.tsx
@@ -739,10 +739,9 @@ export const ModularDashboard = () => {
                 items={modules.filter(m => m.enabled).map(m => m.id)}
                 strategy={rectSortingStrategy}
               >
-                <div 
-                  className="grid gap-6 auto-rows-min"
+                <div
+                  className="grid gap-6 auto-rows-min grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
                   style={{
-                    gridTemplateColumns: 'repeat(4, 1fr)',
                     gridAutoRows: 'minmax(300px, auto)'
                   }}
                 >


### PR DESCRIPTION
## Summary
- make dashboard module grid responsive on small screens
- wrap modules in collapsible for mobile devices
- start modules expanded on mobile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_686144f670388320bb22f0f7b027253d