### PR TITLE
Fix dashboard module collapse height

### DIFF
--- a/src/components/dashboard/MagneticDraggableModule.tsx
+++ b/src/components/dashboard/MagneticDraggableModule.tsx
@@ -78,8 +78,8 @@ export const MagneticDraggableModule = ({
       onMouseUp={handleDragEnd}
       onTouchEnd={handleDragEnd}
     >
-      <Collapsible open={open} onOpenChange={setOpen} className="h-full">
-        <Card className="bg-white h-full border-2 border-transparent hover:border-blue-200 transition-colors flex flex-col">
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <Card className="bg-white border-2 border-transparent hover:border-blue-200 transition-colors flex flex-col">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <div className="flex items-center gap-2">
               <div

--- a/src/components/dashboard/ModularDashboard.tsx
+++ b/src/components/dashboard/ModularDashboard.tsx
@@ -742,7 +742,7 @@ export const ModularDashboard = () => {
                 <div
                   className="grid gap-6 auto-rows-min grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
                   style={{
-                    gridAutoRows: 'minmax(300px, auto)'
+                    gridAutoRows: 'max-content'
                   }}
                 >
                   {modules


### PR DESCRIPTION
## Summary
- ensure collapsible modules shrink fully
- make dashboard rows adapt to module content

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6861588fe8f0832089fae424735dd77d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dashboard module styling to improve layout flexibility by adjusting grid row sizing and removing fixed height constraints from certain components. This may result in modules adapting more closely to their content size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->