### PR TITLE
Adjust onboarding flow

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -160,6 +160,9 @@ export const Dashboard = () => {
 
       console.log("Household created:", household);
 
+      // Set the newly created household as active so we can show its tasks
+      setActiveHousehold(household)
+
       // Add members if any
       if (data.members && data.members.length > 0) {
         const validMembers = data.members.filter((m: any) => m.name.trim() && m.email.trim())
@@ -183,7 +186,13 @@ export const Dashboard = () => {
   }
 
   const handleOnboardingSuccessComplete = () => {
-    setViewMode('dashboard')
+    if (activeHousehold) {
+      // Jump directly to the task list so the user can review the generated checklist
+      setViewMode('task-list')
+    } else {
+      setViewMode('dashboard')
+    }
+
     toast({
       title: "Willkommen bei muutto! 🎉",
       description: `Dein Haushalt "${onboardingData?.householdName}" ist bereit. Lass uns mit der Planung beginnen!`


### PR DESCRIPTION
## Summary
- make the created household active when onboarding finishes
- after the success screen open the task list instead of the dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861b7022c5c8320b83919a8dbe61f55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically sets the newly created household as active upon onboarding completion, allowing immediate access to related tasks.
  * After onboarding, the view now switches to the task list if a household is active, improving navigation.

* **User Experience**
  * Streamlined onboarding flow for quicker access to household tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->