### PR TITLE
Enhance timeline calendar UX

### DIFF
--- a/src/components/tasks/CreateTaskDialog.tsx
+++ b/src/components/tasks/CreateTaskDialog.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import { format } from 'date-fns'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+
+interface CreateTaskDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  date: Date
+  onCreate: (title: string) => Promise<void>
+}
+
+export function CreateTaskDialog({ open, onOpenChange, date, onCreate }: CreateTaskDialogProps) {
+  const [title, setTitle] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmed = title.trim()
+    if (!trimmed) return
+    setSubmitting(true)
+    try {
+      await onCreate(trimmed)
+      setTitle('')
+      onOpenChange(false)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Neue Aufgabe</DialogTitle>
+          <DialogDescription>
+            Aufgabe für {format(date, 'dd.MM.yyyy')}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            placeholder="Titel eingeben"
+            autoFocus
+          />
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline" type="button">
+                Abbrechen
+              </Button>
+            </DialogClose>
+            <Button type="submit" disabled={submitting}>
+              Anlegen
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- replace prompt with CreateTaskDialog modal
- show due date text with improved toast formatting
- enable adding tasks via modal on calendar date click

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68623cc0c1b083209e238c51ac6a6062