### PR TITLE
Enable household details and invite sharing

### DIFF
--- a/src/components/dashboard/ModularDashboard.tsx
+++ b/src/components/dashboard/ModularDashboard.tsx
@@ -45,6 +45,8 @@ import { OnboardingSuccess } from '@/components/onboarding/OnboardingSuccess'
 import { AIAssistant } from '@/components/ai/AIAssistant'
 import { ReminderSystem } from '@/components/reminders/ReminderSystem'
 import { MovingInsights } from '@/components/insights/MovingInsights'
+import { HouseholdOverview } from '../household/HouseholdOverview'
+import { MemberManagement } from '../household/MemberManagement'
 
 export const ModularDashboard = () => {
   const { user, signOut } = useAuth()
@@ -52,7 +54,7 @@ export const ModularDashboard = () => {
   const { toast } = useToast()
   const [activeHousehold, setActiveHousehold] = useState<ExtendedHousehold | null>(null)
   const [activeTab, setActiveTab] = useState('dashboard')
-  const [viewMode, setViewMode] = useState<'dashboard' | 'onboarding' | 'onboarding-success'>('dashboard')
+  const [viewMode, setViewMode] = useState<'dashboard' | 'onboarding' | 'onboarding-success' | 'household-overview' | 'member-management'>('dashboard')
   const [onboardingData, setOnboardingData] = useState<any>(null)
   
   // Aggregated statistics state
@@ -91,7 +93,13 @@ export const ModularDashboard = () => {
                   <p className="font-semibold">{firstHousehold.household_size} Personen</p>
                 </div>
               </div>
-              <Button variant="outline" className="w-full">Details anzeigen</Button>
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={() => openHousehold(firstHousehold)}
+              >
+                Details anzeigen
+              </Button>
             </div>
           ),
           enabled: true,
@@ -461,6 +469,20 @@ export const ModularDashboard = () => {
     })
   }
 
+  const openHousehold = (household: ExtendedHousehold) => {
+    setActiveHousehold(household)
+    setViewMode('household-overview')
+  }
+
+  const showMemberManagement = () => {
+    setViewMode('member-management')
+  }
+
+  const backToDashboard = () => {
+    setViewMode('dashboard')
+    setActiveHousehold(null)
+  }
+
   // Show auth page if not logged in
   if (!user && !loading) {
     return (
@@ -478,6 +500,57 @@ export const ModularDashboard = () => {
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
           <p className="text-gray-600">Lädt Dashboard...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (viewMode === 'household-overview' && activeHousehold) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
+        <div className="max-w-6xl mx-auto">
+          <div className="flex items-center mb-6">
+            <Button variant="ghost" onClick={backToDashboard} className="mr-4">
+              ← Zurück zum Dashboard
+            </Button>
+            <h1 className="text-2xl font-bold text-gray-900">Haushalt verwalten</h1>
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <div className="lg:col-span-2">
+              <HouseholdOverview
+                household={activeHousehold}
+                onManageMembers={showMemberManagement}
+                onEditHousehold={() => {}}
+                onViewTasks={() => {}}
+              />
+            </div>
+
+            <div className="space-y-6">
+              <MovingInsights household={activeHousehold} />
+              <AIAssistant household={activeHousehold} />
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (viewMode === 'member-management' && activeHousehold) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
+        <div className="max-w-6xl mx-auto">
+          <div className="flex items-center mb-6">
+            <Button variant="ghost" onClick={() => setViewMode('household-overview')} className="mr-4">
+              ← Zurück zur Übersicht
+            </Button>
+            <h1 className="text-2xl font-bold text-gray-900">Mitglieder verwalten</h1>
+          </div>
+
+          <MemberManagement
+            householdId={activeHousehold.id}
+            isOwner={activeHousehold.created_by === user?.id}
+          />
         </div>
       </div>
     )

--- a/src/components/household/MemberManagement.tsx
+++ b/src/components/household/MemberManagement.tsx
@@ -12,7 +12,7 @@ import { useHouseholdMembers } from '@/hooks/useHouseholdMembers'
 import { useAuth } from '@/contexts/AuthContext'
 import { HOUSEHOLD_ROLES, getRoleIcon, getRoleColor } from '@/config/roles'
 import { HouseholdRole } from '@/types/household'
-import { Users, UserPlus, Mail, Crown, Clock, CheckCircle, Trash2, Settings, Copy } from 'lucide-react'
+import { Users, UserPlus, Mail, Crown, Clock, CheckCircle, Trash2, Settings, Copy, Link2, MessageCircle } from 'lucide-react'
 import { useToast } from '@/hooks/use-toast'
 import { supabase } from '@/integrations/supabase/client'
 
@@ -137,22 +137,51 @@ export const MemberManagement = ({ householdId, isOwner = false }: MemberManagem
             {members.length} {members.length === 1 ? 'Mitglied' : 'Mitglieder'}
           </p>
           {isOwner && invitationCode && (
-            <div className="flex items-center mt-2 space-x-2">
-              <span className="text-sm text-gray-600">Einladungscode:</span>
-              <span className="font-mono text-sm bg-gray-100 px-2 py-1 rounded">
-                {invitationCode}
-              </span>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  navigator.clipboard.writeText(invitationCode)
-                  toast({ title: 'Code kopiert' })
-                }}
-              >
-                <Copy className="h-3 w-3 mr-1" />
-                Kopieren
-              </Button>
+            <div className="flex flex-col mt-2 space-y-2">
+              <div className="flex items-center space-x-2">
+                <span className="text-sm text-gray-600">Einladungscode:</span>
+                <span className="font-mono text-sm bg-gray-100 px-2 py-1 rounded">
+                  {invitationCode}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    navigator.clipboard.writeText(invitationCode)
+                    toast({ title: 'Code kopiert' })
+                  }}
+                >
+                  <Copy className="h-3 w-3 mr-1" />
+                  Kopieren
+                </Button>
+              </div>
+              <div className="flex items-center space-x-2">
+                <span className="text-sm text-gray-600">Einladungslink:</span>
+                <span className="font-mono text-sm bg-gray-100 px-2 py-1 rounded break-all">
+                  {`${window.location.origin}?invite=${invitationCode}`}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    navigator.clipboard.writeText(`${window.location.origin}?invite=${invitationCode}`)
+                    toast({ title: 'Link kopiert' })
+                  }}
+                >
+                  <Link2 className="h-3 w-3 mr-1" />
+                  Link kopieren
+                </Button>
+                <a
+                  href={`https://wa.me/?text=${encodeURIComponent(`Tritt meinem Haushalt bei: ${window.location.origin}?invite=${invitationCode}`)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Button variant="outline" size="sm">
+                    <MessageCircle className="h-3 w-3 mr-1" />
+                    WhatsApp
+                  </Button>
+                </a>
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- allow opening a detailed household view from the dashboard module
- add member management and detail views in `ModularDashboard`
- extend `MemberManagement` with link and WhatsApp sharing of invitation code

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686263ffeaf08320a97be8fb2bd0e4ff