### PR TITLE
Add task dialog improvements

### DIFF
--- a/docs/CHATBOT_PROGRESS.md
+++ b/docs/CHATBOT_PROGRESS.md
@@ -1,0 +1,12 @@
+# Fortschritt KI-Integration
+
+## 2025-06-30
+- Chatbot kann jetzt direkt Aufgaben aus Nachrichten anlegen.
+- Dazu wurde ein Dialog *AddTaskFromChatDialog* implementiert.
+- Nachrichten lassen sich per Button in eine Aufgabe umwandeln; ein Datum wird mittels `chrono-node` aus dem Text erkannt.
+- Die Aufgabe wird in der Supabase-Tabelle `tasks` gespeichert und erscheint in Erinnerungen und Timeline.
+
+## Weitere Ideen
+- Automatische Erkennung von Terminen und Erstellen von Kalender-Einträgen (iCal Export).
+- Vorlagen für häufige Schreiben (z.B. Kündigungen) direkt aus dem Chat anbieten.
+- Sprachsteuerung für noch schnellere Eingabe.

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@radix-ui/react-tooltip": "^1.1.4",
         "@supabase/supabase-js": "^2.50.2",
         "@tanstack/react-query": "^5.56.2",
+        "chrono-node": "^2.8.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -3745,6 +3746,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chrono-node": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.8.3.tgz",
+      "integrity": "sha512-YukiXak31pshonVWaeJ9cZ4xxWIlbsyn5qYUkG5pQ+usZ6l22ASXDIk0kHUQkIBNOCLRevFkHJjnGKXwZNtyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.10.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -4355,6 +4368,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.7",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@supabase/supabase-js": "^2.50.2",
     "@tanstack/react-query": "^5.56.2",
+    "chrono-node": "^2.8.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/src/components/ai/AIAssistant.tsx
+++ b/src/components/ai/AIAssistant.tsx
@@ -7,10 +7,11 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Badge } from '@/components/ui/badge'
 import { useAuth } from '@/contexts/AuthContext'
 import { useToast } from '@/hooks/use-toast'
-import { Bot, User, Send, Loader2, Sparkles } from 'lucide-react'
+import { Bot, User, Send, Loader2, Sparkles, PlusCircle } from 'lucide-react'
 import { ExtendedHousehold } from '@/types/household'
 import { supabase } from '@/integrations/supabase/client'
 import { AIConsentDialog } from './AIConsentDialog'
+import { AddTaskFromChatDialog } from '../tasks/AddTaskFromChatDialog'
 import { useUserConsent } from '@/hooks/useUserConsent'
 import { generatePersonalizedWelcomeMessage, buildHouseholdContext } from '@/utils/aiPersonalization'
 
@@ -36,6 +37,8 @@ export const AIAssistant = ({ household, className }: AIAssistantProps) => {
   const [isLoading, setIsLoading] = useState(false)
   const [isInitialized, setIsInitialized] = useState(false)
   const [sessionId, setSessionId] = useState<string | null>(null)
+  const [taskDialogOpen, setTaskDialogOpen] = useState(false)
+  const [taskMessage, setTaskMessage] = useState<string>('')
   const scrollAreaRef = useRef<HTMLDivElement>(null)
 
   // Initialize with personalized welcome message when consent is given
@@ -241,6 +244,7 @@ Versuche es gleich nochmal - ich bin normalerweise sofort da! 😊`,
   }
 
   return (
+    <>
     <Card className={`h-[600px] flex flex-col ${className}`}>
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2">
@@ -303,6 +307,17 @@ Versuche es gleich nochmal - ich bin normalerweise sofort da! 😊`,
                       ))}
                     </div>
                   )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-xs h-6 mt-2 flex items-center gap-1"
+                    onClick={() => {
+                      setTaskMessage(message.content)
+                      setTaskDialogOpen(true)
+                    }}
+                  >
+                    <PlusCircle className="h-3 w-3" /> Aufgabe
+                  </Button>
                 </div>
                 
                 {message.role === 'user' && (
@@ -357,5 +372,12 @@ Versuche es gleich nochmal - ich bin normalerweise sofort da! 😊`,
         </div>
       </CardContent>
     </Card>
+    <AddTaskFromChatDialog
+      open={taskDialogOpen}
+      onOpenChange={setTaskDialogOpen}
+      message={taskMessage}
+      householdId={household?.id}
+    />
+    </>
   )
 }

--- a/src/components/tasks/AddTaskFromChatDialog.tsx
+++ b/src/components/tasks/AddTaskFromChatDialog.tsx
@@ -1,0 +1,88 @@
+import { useState, useEffect } from 'react'
+import { format } from 'date-fns'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Calendar } from '@/components/ui/calendar'
+import { useTasks } from '@/hooks/useTasks'
+import { extractDate } from '@/utils/dateParsing'
+
+interface AddTaskFromChatDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  message: string
+  householdId?: string
+  defaultPhase?: string
+  defaultPriority?: string
+}
+
+export function AddTaskFromChatDialog({
+  open,
+  onOpenChange,
+  message,
+  householdId,
+  defaultPhase = 'vor_umzug',
+  defaultPriority = 'mittel',
+}: AddTaskFromChatDialogProps) {
+  const { createTask } = useTasks(householdId)
+  const [title, setTitle] = useState(message)
+  const [date, setDate] = useState<Date | undefined>(() => extractDate(message) || undefined)
+  const [submitting, setSubmitting] = useState(false)
+
+  // Reset state when dialog (re)opens
+  useEffect(() => {
+    if (open) {
+      setTitle(message)
+      setDate(extractDate(message) || undefined)
+    }
+  }, [open, message])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!title.trim()) return
+    setSubmitting(true)
+    try {
+      await createTask({
+        title: title.trim(),
+        phase: defaultPhase,
+        priority: defaultPriority,
+        due_date: date ? format(date, 'yyyy-MM-dd') : null,
+      })
+      onOpenChange(false)
+      // reset after success
+      setTitle(message)
+      setDate(extractDate(message) || undefined)
+    } catch (error) {
+      console.error('Failed to create task:', error)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Aufgabe aus Chat erstellen</DialogTitle>
+          <DialogDescription>Bearbeite Titel und wähle optional ein Fälligkeitsdatum.</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Aufgabentitel eingeben..."
+            required
+            aria-label="Aufgabentitel"
+          />
+          <Calendar mode="single" selected={date} onSelect={setDate} className="rounded-md border" />
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline" type="button">Abbrechen</Button>
+            </DialogClose>
+            <Button type="submit" disabled={submitting}>Speichern</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/utils/dateParsing.ts
+++ b/src/utils/dateParsing.ts
@@ -1,0 +1,11 @@
+import { de } from 'chrono-node'
+
+export function extractDate(text: string): Date | null {
+  try {
+    const result = de.parse(text)[0]
+    return result ? result.start.date() : null
+  } catch (error) {
+    console.warn('Date parsing failed:', error)
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- refine docs formatting for chatbot progress
- make task dialog configurable and reset state when reopened
- add input validation and error handling
- add robust date parsing with try/catch

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6862527cfbfc8320bc2a34ae7151bc38