### PR TITLE
Improve member invite button state

### DIFF
--- a/src/components/dashboard/ModularDashboard.tsx
+++ b/src/components/dashboard/ModularDashboard.tsx
@@ -56,6 +56,7 @@ export const ModularDashboard = () => {
   const [activeTab, setActiveTab] = useState('dashboard')
   const [viewMode, setViewMode] = useState<'dashboard' | 'onboarding' | 'onboarding-success' | 'household-overview' | 'member-management'>('dashboard')
   const [onboardingData, setOnboardingData] = useState<any>(null)
+  const [navigationLoading, setNavigationLoading] = useState(false)
   
   // Aggregated statistics state
   const [totalTasks, setTotalTasks] = useState(0)
@@ -97,6 +98,7 @@ export const ModularDashboard = () => {
                 variant="outline"
                 className="w-full"
                 onClick={() => openHousehold(firstHousehold)}
+                disabled={navigationLoading}
               >
                 Details anzeigen
               </Button>
@@ -470,8 +472,10 @@ export const ModularDashboard = () => {
   }
 
   const openHousehold = (household: ExtendedHousehold) => {
+    setNavigationLoading(true)
     setActiveHousehold(household)
     setViewMode('household-overview')
+    setNavigationLoading(false)
   }
 
   const showMemberManagement = () => {
@@ -541,7 +545,7 @@ export const ModularDashboard = () => {
       <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
         <div className="max-w-6xl mx-auto">
           <div className="flex items-center mb-6">
-            <Button variant="ghost" onClick={() => setViewMode('household-overview')} className="mr-4">
+            <Button variant="ghost" onClick={() => setViewMode('household-overview')} className="mr-4" aria-label="Zurück zur Haushaltsübersicht">
               ← Zurück zur Übersicht
             </Button>
             <h1 className="text-2xl font-bold text-gray-900">Mitglieder verwalten</h1>

--- a/src/components/household/MemberManagement.tsx
+++ b/src/components/household/MemberManagement.tsx
@@ -154,6 +154,7 @@ export const MemberManagement = ({ householdId, isOwner = false }: MemberManagem
                 <Button
                   variant="outline"
                   size="sm"
+                  disabled={!invitationCode}
                   onClick={() => {
                     try {
                       navigator.clipboard.writeText(invitationCode)


### PR DESCRIPTION
## Summary
- disable member invite code button when no code
- add navigation loading state to ModularDashboard
- disable household open button while navigating
- add `aria-label` on back navigation button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68626da097f08320ab2940bc45623c5a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved accessibility by adding an aria-label to the back button in member management.
* **Bug Fixes**
  * Disabled the "Details anzeigen" button during navigation to prevent unintended actions.
  * Disabled the "Kopieren" button for invitation codes when no code is available, preventing empty copies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->