### PR TITLE
Add dashboard skeleton and lazy load modules

### DIFF
--- a/src/components/dashboard/DashboardSkeleton.tsx
+++ b/src/components/dashboard/DashboardSkeleton.tsx
@@ -1,0 +1,22 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export const DashboardSkeleton = () => {
+  const placeholders = Array.from({ length: 4 });
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      {placeholders.map((_, i) => (
+        <Card key={i}>
+          <CardHeader>
+            <CardTitle>
+              <Skeleton className="h-4 w-1/2" />
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-24 w-full" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,11 @@
+import { Suspense, lazy } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
-import { ModularDashboard } from '@/components/dashboard/ModularDashboard';
 import { AuthPage } from '@/components/auth/AuthPage';
+import { DashboardSkeleton } from '@/components/dashboard/DashboardSkeleton';
+
+const ModularDashboard = lazy(() =>
+  import('@/components/dashboard/ModularDashboard')
+);
 
 const Index = () => {
   const { user, loading } = useAuth();
@@ -22,7 +27,9 @@ const Index = () => {
 
   return (
     <div>
-      <ModularDashboard />
+      <Suspense fallback={<DashboardSkeleton />}>
+        <ModularDashboard />
+      </Suspense>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- lazy load `ModularDashboard` to avoid blank screen during load
- add a `DashboardSkeleton` placeholder
- show the skeleton while the dashboard component loads

## Testing
- `npm run lint` *(fails: 31 errors, 19 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68626edb68288320b1e0913122fea791