### PR TITLE
Add legal pages and footer navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,10 @@ import Index from "./pages/Index";
 import Timeline from "./pages/Timeline";
 import Settings from "./pages/Settings";
 import NotFound from "./pages/NotFound";
+import Impressum from "./pages/Impressum";
+import Datenschutz from "./pages/Datenschutz";
+import AGB from "./pages/AGB";
+import Kontakt from "./pages/Kontakt";
 import { AppShell } from "@/components/layout/AppShell";
 
 const queryClient = new QueryClient();
@@ -24,6 +28,10 @@ const App = () => (
               <Route path="/" element={<Index />} />
               <Route path="/timeline" element={<Timeline />} />
               <Route path="/settings" element={<Settings />} />
+              <Route path="/impressum" element={<Impressum />} />
+              <Route path="/datenschutz" element={<Datenschutz />} />
+              <Route path="/agb" element={<AGB />} />
+              <Route path="/kontakt" element={<Kontakt />} />
               <Route path="*" element={<NotFound />} />
             </Routes>
           </AppShell>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,11 +1,13 @@
 import { ReactNode } from 'react'
 import { TopNav } from './TopNav'
+import { Footer } from './Footer'
 
 export const AppShell = ({ children }: { children: ReactNode }) => {
   return (
     <div className="min-h-screen flex flex-col">
       <TopNav />
       <main className="flex-1 p-4">{children}</main>
+      <Footer />
     </div>
   )
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,29 @@
+import { Link } from 'react-router-dom'
+
+interface Item {
+  label: string
+  to: string
+}
+
+const items: Item[] = [
+  { label: 'Impressum', to: '/impressum' },
+  { label: 'Datenschutz', to: '/datenschutz' },
+  { label: 'AGB', to: '/agb' },
+  { label: 'Kontakt', to: '/kontakt' }
+]
+
+export const Footer = () => {
+  return (
+    <footer className="border-t border-border bg-background" role="contentinfo">
+      <ul className="flex flex-wrap justify-center space-x-4 p-4 text-sm text-muted-foreground">
+        {items.map((item) => (
+          <li key={item.to}>
+            <Link to={item.to} className="hover:text-primary">
+              {item.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </footer>
+  )
+}

--- a/src/pages/AGB.tsx
+++ b/src/pages/AGB.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const AGB = () => {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Allgemeine Geschäftsbedingungen</h1>
+      <p className="mb-2">Hier stehen künftig die AGB von Muutto.</p>
+    </div>
+  )
+}
+
+export default AGB

--- a/src/pages/Datenschutz.tsx
+++ b/src/pages/Datenschutz.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+const Datenschutz = () => {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Datenschutzerklärung</h1>
+      <p className="mb-2">Wir nehmen den Schutz Ihrer Daten ernst.</p>
+      <p className="mb-2">Diese Seite dient als Platzhalter für detaillierte Datenschutzinformationen.</p>
+    </div>
+  )
+}
+
+export default Datenschutz

--- a/src/pages/Impressum.tsx
+++ b/src/pages/Impressum.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const Impressum = () => {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Impressum</h1>
+      <p className="mb-2">Angaben gemäß § 5 TMG</p>
+      <p className="mb-2">Muutto GmbH<br/>Musterstraße 1<br/>12345 Berlin</p>
+      <p className="mb-2">Vertreten durch: Max Mustermann</p>
+      <p>Kontakt: info@muutto.de, Fax: +49 30 1234567</p>
+    </div>
+  )
+}
+
+export default Impressum

--- a/src/pages/Kontakt.tsx
+++ b/src/pages/Kontakt.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+const Kontakt = () => {
+  return (
+    <div className="max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Kontakt</h1>
+      <p className="mb-2">Muutto GmbH</p>
+      <p className="mb-2">Musterstraße 1, 12345 Berlin</p>
+      <p className="mb-2">Telefon: +49 30 1234560</p>
+      <p className="mb-2">Fax: +49 30 1234567</p>
+      <p>E-Mail: info@muutto.de</p>
+    </div>
+  )
+}
+
+export default Kontakt


### PR DESCRIPTION
## Summary
- add Impressum, Datenschutz, AGB and Kontakt pages
- create a simple footer with navigation links
- include the footer in the layout and register new routes

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68626f406b5883209d60ed03b101bbe6