### PR TITLE
Fix default export for ModularDashboard

### DIFF
--- a/src/components/dashboard/ModularDashboard.tsx
+++ b/src/components/dashboard/ModularDashboard.tsx
@@ -883,7 +883,7 @@ const Cloud = ({ className }: { className?: string }) => (
 )
 
 const Sun = ({ className }: { className?: string }) => (
-  <svg 
+  <svg
     xmlns="http://www.w3.org/2000/svg" 
     viewBox="0 0 24 24" 
     fill="none" 
@@ -904,3 +904,5 @@ const Sun = ({ className }: { className?: string }) => (
     <path d="m19.07 4.93-1.41 1.41" />
   </svg>
 )
+
+export default ModularDashboard


### PR DESCRIPTION
## Summary
- add missing default export for the `ModularDashboard` component

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686275f75d7083208c378b2a808a6fe6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved formatting in the Sun icon component.
  * Updated the export method for the ModularDashboard component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->