### PR TITLE
Fix dashboard module serialization

### DIFF
--- a/src/hooks/useEnhancedDashboardModules.ts
+++ b/src/hooks/useEnhancedDashboardModules.ts
@@ -42,8 +42,12 @@ export const useEnhancedDashboardModules = (initialModules: DashboardModule[]) =
     
     if (savedModules) {
       try {
-        const parsedModules = JSON.parse(savedModules);
-        setModules(parsedModules);
+        const parsedModules = JSON.parse(savedModules) as Partial<DashboardModule>[];
+        const mergedModules = initialModules.map((initial) => {
+          const saved = parsedModules.find((m) => m.id === initial.id);
+          return { ...initial, ...saved };
+        });
+        setModules(mergedModules);
       } catch (error) {
         console.error('Error parsing saved modules:', error);
       }
@@ -79,7 +83,15 @@ export const useEnhancedDashboardModules = (initialModules: DashboardModule[]) =
   // Save modules to localStorage when they change
   useEffect(() => {
     if (modules.length > 0) {
-      localStorage.setItem('dashboard_modules_v2', JSON.stringify(modules));
+      const serializable = modules.map(({ id, title, enabled, category, description, size }) => ({
+        id,
+        title,
+        enabled,
+        category,
+        description,
+        size,
+      }));
+      localStorage.setItem('dashboard_modules_v2', JSON.stringify(serializable));
     }
   }, [modules]);
 


### PR DESCRIPTION
## Summary
- merge saved dashboard module data with React nodes at load time
- only save serializable dashboard module fields to local storage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68627a696acc832096b63e641f9cf89e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how dashboard modules are loaded from and saved to local storage for better data consistency and efficiency. Only essential module information is now stored, and saved data is merged with default modules on load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->