### PR TITLE
Add QR code invites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "react-grid-layout": "^1.5.2",
         "react-hook-form": "^7.53.0",
         "react-leaflet": "^4.2.1",
+        "react-qr-code": "^2.0.16",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
         "recharts": "^2.12.7",
@@ -6335,6 +6336,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6466,6 +6473,19 @@
         "leaflet": "^1.9.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/react-qr-code": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.16.tgz",
+      "integrity": "sha512-8f54aTOo7DxYr1LB47pMeclV5SL/zSbJxkXHIS2a+QnAIa4XDVIdmzYRC+CBCJeDLSCeFHn8gHtltwvwZGJD/w==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1",
+        "qr.js": "0.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-remove-scroll": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "react-grid-layout": "^1.5.2",
     "react-hook-form": "^7.53.0",
     "react-leaflet": "^4.2.1",
+    "react-qr-code": "^2.0.16",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-grid-layout": "^1.5.2",
     "react-hook-form": "^7.53.0",
     "react-leaflet": "^4.2.1",
-    "react-qr-code": "^2.0.16",
+    "react-qr-code": "^2.0.15",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
     "recharts": "^2.12.7",

--- a/src/components/household/MemberManagement.tsx
+++ b/src/components/household/MemberManagement.tsx
@@ -12,7 +12,9 @@ import { useHouseholdMembers } from '@/hooks/useHouseholdMembers'
 import { useAuth } from '@/contexts/AuthContext'
 import { HOUSEHOLD_ROLES, getRoleIcon, getRoleColor } from '@/config/roles'
 import { HouseholdRole } from '@/types/household'
-import { Users, UserPlus, Mail, Crown, Clock, CheckCircle, Trash2, Settings, Copy, Link2, MessageCircle } from 'lucide-react'
+import { Users, UserPlus, Mail, Crown, Clock, CheckCircle, Trash2, Settings, Copy, Link2, MessageCircle, QrCode } from 'lucide-react'
+import QRCode from 'react-qr-code'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
 import { useToast } from '@/hooks/use-toast'
 import { supabase } from '@/integrations/supabase/client'
 
@@ -189,7 +191,7 @@ export const MemberManagement = ({ householdId, isOwner = false }: MemberManagem
                   <Link2 className="h-3 w-3 mr-1" />
                   Link kopieren
                 </Button>
-                <a
+              <a
                   href={whatsappUrl}
                   target="_blank"
                   rel="noopener noreferrer"
@@ -199,6 +201,19 @@ export const MemberManagement = ({ householdId, isOwner = false }: MemberManagem
                     WhatsApp
                   </Button>
                 </a>
+                {invitationLink && (
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button variant="outline" size="sm">
+                        <QrCode className="h-3 w-3 mr-1" />
+                        QR-Code
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="flex justify-center">
+                      <QRCode value={invitationLink} size={128} />
+                    </PopoverContent>
+                  </Popover>
+                )}
               </div>
             </div>
           )}

--- a/src/components/household/MemberManagement.tsx
+++ b/src/components/household/MemberManagement.tsx
@@ -204,13 +204,25 @@ export const MemberManagement = ({ householdId, isOwner = false }: MemberManagem
                 {invitationLink && (
                   <Popover>
                     <PopoverTrigger asChild>
-                      <Button variant="outline" size="sm">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        aria-label="QR-Code für Einladungslink anzeigen"
+                      >
                         <QrCode className="h-3 w-3 mr-1" />
                         QR-Code
                       </Button>
                     </PopoverTrigger>
-                    <PopoverContent className="flex justify-center">
-                      <QRCode value={invitationLink} size={128} />
+                    <PopoverContent
+                      className="flex justify-center"
+                      aria-label="QR-Code des Einladungslinks"
+                    >
+                      <div
+                        role="img"
+                        aria-label={`QR-Code für Einladungslink: ${invitationLink}`}
+                      >
+                        <QRCode value={invitationLink} size={128} />
+                      </div>
                     </PopoverContent>
                   </Popover>
                 )}


### PR DESCRIPTION
## Summary
- add `react-qr-code` to render QR codes
- show QR code popover in member management with invitation link

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build:dev`

------
https://chatgpt.com/codex/tasks/task_e_686375cb1b14832080fe37f68804a970

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability for household owners to display a QR code for the invitation link, accessible via a new "QR-Code" button in the member invitation section. Scanning the QR code allows quick access to the invitation link.

* **Chores**
  * Added a new dependency to support QR code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->