### PR TITLE
Improve timeline interaction

### DIFF
--- a/src/components/tasks/EditTaskDialog.tsx
+++ b/src/components/tasks/EditTaskDialog.tsx
@@ -1,0 +1,64 @@
+import { useState, useEffect } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { Calendar } from '@/components/ui/calendar'
+import { format } from 'date-fns'
+import { TimelineItem } from '@/types/timeline'
+import { useTasks } from '@/hooks/useTasks'
+
+interface EditTaskDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  householdId?: string
+  task: TimelineItem | null
+}
+
+export function EditTaskDialog({ open, onOpenChange, householdId, task }: EditTaskDialogProps) {
+  const { updateTask } = useTasks(householdId)
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [date, setDate] = useState<Date | undefined>()
+
+  useEffect(() => {
+    if (task) {
+      setTitle(task.title)
+      setDescription(task.description)
+      setDate(task.start ? new Date(task.start) : undefined)
+    }
+  }, [task])
+
+  const handleSave = async () => {
+    if (!task) return
+    await updateTask(task.id, {
+      title,
+      description,
+      due_date: date ? format(date, 'yyyy-MM-dd') : null
+    })
+    onOpenChange(false)
+  }
+
+  if (!task) return null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Aufgabe bearbeiten</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <Input value={title} onChange={e => setTitle(e.target.value)} />
+          <Textarea value={description || ''} onChange={e => setDescription(e.target.value)} />
+          <Calendar mode="single" selected={date} onSelect={setDate} className="rounded-md border" />
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Abbrechen</Button>
+            </DialogClose>
+            <Button onClick={handleSave}>Speichern</Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- compute timeline range based on all tasks
- allow editing tasks in new dialog
- display move date with a star icon
- show timeline date headers again

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68637a27ef7883208acefc308be30103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive dialog for editing tasks directly from the timeline view.
  * Enabled double-clicking a task on the timeline to open the edit dialog.
  * Timeline range now automatically adjusts based on task dates or household move date.
  * Added a star icon next to the move day label for improved visual clarity.

* **User Interface**
  * Improved timeline scrolling and visual presentation for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->