### PR TITLE
Add collapsible module cards

### DIFF
--- a/src/components/dashboard/SimpleModuleCard.tsx
+++ b/src/components/dashboard/SimpleModuleCard.tsx
@@ -1,4 +1,7 @@
+import { useState } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { ChevronDown, ChevronUp } from 'lucide-react'
 import type { DashboardModule } from '@/hooks/useEnhancedDashboardModules'
 
 interface SimpleModuleCardProps {
@@ -18,22 +21,52 @@ const getMinHeight = (size: 'small' | 'medium' | 'large') => {
   }
 }
 
-export const SimpleModuleCard = ({ module }: SimpleModuleCardProps) => (
-  <Card 
-    className={`bg-white shadow-lg flex flex-col ${getMinHeight(module.size)}`}
-    role="article"
-    aria-label={`${module.title} module`}
-  >
-    <CardHeader className="flex flex-row items-center pb-2">
-      <div className="flex items-center gap-2">
-        <span aria-hidden="true">{module.icon}</span>
-        <CardTitle className="text-sm font-medium">{module.title}</CardTitle>
-      </div>
-    </CardHeader>
-    <CardContent className="flex-1 overflow-auto">
-      {module.component}
-    </CardContent>
-  </Card>
-)
+const getMaxHeight = (size: 'small' | 'medium' | 'large') => {
+  switch (size) {
+    case 'small':
+      return 'max-h-[240px]'
+    case 'medium':
+      return 'max-h-[360px]'
+    case 'large':
+      return 'max-h-[480px]'
+    default:
+      return 'max-h-[360px]'
+  }
+}
+
+export const SimpleModuleCard = ({ module }: SimpleModuleCardProps) => {
+  const [open, setOpen] = useState(true)
+
+  const heightClasses = open
+    ? `${getMinHeight(module.size)} ${getMaxHeight(module.size)}`
+    : 'min-h-0'
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <Card
+        className={`bg-white shadow-lg flex flex-col transition-all duration-200 ${heightClasses}`}
+        role="article"
+        aria-label={`${module.title} module`}
+      >
+        <CardHeader className="flex flex-row items-center pb-2">
+          <div className="flex items-center gap-2 flex-1">
+            <span aria-hidden="true">{module.icon}</span>
+            <CardTitle className="text-sm font-medium truncate">{module.title}</CardTitle>
+          </div>
+          <CollapsibleTrigger asChild>
+            <button className="p-1 rounded hover:bg-gray-100" aria-label="Modul umschalten">
+              {open ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+            </button>
+          </CollapsibleTrigger>
+        </CardHeader>
+        <CollapsibleContent className="flex-1 flex flex-col">
+          <CardContent className="flex-1 overflow-auto">
+            {module.component}
+          </CardContent>
+        </CollapsibleContent>
+      </Card>
+    </Collapsible>
+  )
+}
 
 export default SimpleModuleCard


### PR DESCRIPTION
## Summary
- allow SimpleModuleCard modules to collapse and expand
- limit module height and allow scrolling of long content

## Testing
- `npm run lint` *(fails: several repo-wide lint errors)*
- `npx eslint src/components/dashboard/SimpleModuleCard.tsx`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686668bc9e2c8320b8887167b84f865f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Module cards on the dashboard can now be expanded or collapsed to show or hide content.
  * Animated transitions and toggle icons provide a smoother and more interactive user experience.

* **Refactor**
  * Improved layout and content handling within module cards for better usability and visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->