### PR TITLE
Fix onboarding data types

### DIFF
--- a/src/components/dashboard/ModularDashboard.tsx
+++ b/src/components/dashboard/ModularDashboard.tsx
@@ -6,7 +6,8 @@ import { Home, CheckCircle, Bell, TrendingUp, MapPin, Map as DashboardMap, Truck
 import { useAuth } from '@/contexts/AuthContext'
 import { useHouseholds } from '@/hooks/useHouseholds'
 import { useToast } from '@/hooks/use-toast'
-import { ExtendedHousehold, CreateHouseholdData, OnboardingData } from '@/types/household'
+import { ExtendedHousehold, CreateHouseholdData } from '@/types/household'
+import { OnboardingData as OnboardingFlowData } from '@/components/onboarding/OnboardingFlow'
 import { APP_CONFIG } from '@/config/app'
 import MapModule from '@/components/maps/MapModule'
 import { DashboardStats } from './DashboardStats'
@@ -26,7 +27,7 @@ export const ModularDashboard = () => {
   const { toast } = useToast()
   const [activeHousehold, setActiveHousehold] = useState<ExtendedHousehold | null>(null)
   const [viewMode, setViewMode] = useState<'dashboard' | 'onboarding' | 'onboarding-success' | 'household-overview' | 'member-management'>('dashboard')
-  const [onboardingData, setOnboardingData] = useState<OnboardingData | null>(null)
+  const [onboardingData, setOnboardingData] = useState<{ householdName: string; moveDate: string } | null>(null)
 
   const [modules, setModules] = useState<DashboardModule[]>([])
 
@@ -177,23 +178,23 @@ export const ModularDashboard = () => {
     }
   }, [households])
 
-  const handleOnboardingComplete = async (data: OnboardingData) => {
+  const handleOnboardingComplete = async (data: OnboardingFlowData) => {
     try {
-      setOnboardingData(data)
+      setOnboardingData({ householdName: data.householdName, moveDate: data.moveDate })
 
       const household = await createHousehold({
         name: data.householdName,
         move_date: data.moveDate,
-        household_size: data.householdSize,
-        children_count: data.childrenCount,
-        pets_count: data.petsCount,
-        property_type: data.propertyType as 'miete' | 'eigentum',
-        postal_code: data.postalCode,
-        old_address: data.oldAddress,
-        new_address: data.newAddress,
-        living_space: data.livingSpace,
-        rooms: data.rooms,
-        furniture_volume: data.furnitureVolume
+        household_size: data.adultsCount + data.children.length,
+        children_count: data.children.length,
+        pets_count: data.pets.length,
+        property_type: (data.newHome.propertyType || data.oldHome.propertyType || 'miete') as 'miete' | 'eigentum',
+        postal_code: undefined,
+        old_address: undefined,
+        new_address: undefined,
+        living_space: data.newHome.livingSpace || data.oldHome.livingSpace,
+        rooms: data.newHome.rooms || data.oldHome.rooms,
+        furniture_volume: undefined
       })
 
       if (data.members && data.members.length > 0) {


### PR DESCRIPTION
## Summary
- use OnboardingFlow data in dashboard code
- map onboarding form values when creating households

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npx tsc -p tsconfig.app.json` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_686cbfb61630832092938e1dbc4e7aa6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how onboarding data is processed and mapped when completing onboarding in the dashboard.
  * Updated internal handling of household details, children, and pets counts, and property information for more accurate data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->